### PR TITLE
Initial nRF52 support, tested on 64x32 matrix

### DIFF
--- a/arch.h
+++ b/arch.h
@@ -617,6 +617,8 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
       //return count;
   }
 
+  #define _PM_clockHoldHigh asm("nop; nop");
+
   #define _PM_minMinPeriod 100
 
 #endif // NRF52_SERIES

--- a/arch.h
+++ b/arch.h
@@ -528,8 +528,8 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
 
     // Timer interrupt service routine
     void _PM_IRQ_HANDLER(void) {
-        if(NRF_TIMER3->EVENTS_COMPARE[0]) {
-            NRF_TIMER3->EVENTS_COMPARE[0] = 0;
+        if(_PM_TIMER_DEFAULT->EVENTS_COMPARE[0]) {
+            _PM_TIMER_DEFAULT->EVENTS_COMPARE[0] = 0;
         }
         _PM_row_handler(_PM_protoPtr); // In core.c
     }
@@ -611,7 +611,7 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
       return _PM_timerGetCount(tptr);
   }
 
-  #define _PM_minMinPeriod 1000
+  #define _PM_minMinPeriod 25
 
 #endif // NRF52_SERIES
 

--- a/arch.h
+++ b/arch.h
@@ -140,13 +140,9 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
     // g_APinDescription[] table and pin indices are Arduino specific:
     #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
       #define _PM_byteOffset(pin) (g_APinDescription[pin].ulPin / 8)
-    #else
-      #define _PM_byteOffset(pin) (3 - (g_APinDescription[pin].ulPin / 8))
-    #endif
-
-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
       #define _PM_wordOffset(pin) (g_APinDescription[pin].ulPin / 16)
     #else
+      #define _PM_byteOffset(pin) (3 - (g_APinDescription[pin].ulPin / 8))
       #define _PM_wordOffset(pin) (1 - (g_APinDescription[pin].ulPin / 16))
     #endif
 
@@ -488,34 +484,31 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
 
   #if defined(ARDUINO)
 
-    // g_ADigitalPinMap[] table and pin indices are Arduino specific:
+    // digitalPinToPort, g_ADigitalPinMap[] are Arduino specific:
+
     void *_PM_portOutRegister(uint32_t pin) {
-      NRF_GPIO_Type *port = nrf_gpio_pin_port_decode(&pin);
-      return &port->OUT;
+        NRF_GPIO_Type *port = digitalPinToPort(pin);
+        return &port->OUT;
     }
 
     void *_PM_portSetRegister(uint32_t pin)  {
-      NRF_GPIO_Type *port = nrf_gpio_pin_port_decode(&pin);
-      return &port->OUTSET;
+        NRF_GPIO_Type *port = digitalPinToPort(pin);
+        return &port->OUTSET;
     }
 
     void *_PM_portClearRegister(uint32_t pin) {
-      NRF_GPIO_Type *port = nrf_gpio_pin_port_decode(&pin);
-      return &port->OUTCLR;
+        NRF_GPIO_Type *port = digitalPinToPort(pin);
+        return &port->OUTCLR;
     }
 
     // Leave _PM_portToggleRegister(pin) undefined on nRF!
 
     #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-      #define _PM_byteOffset(pin) (g_ADigitalPinMap[pin & 0x1F] / 8)
+      #define _PM_byteOffset(pin) ((g_ADigitalPinMap[pin] & 0x1F) / 8)
+      #define _PM_wordOffset(pin) ((g_ADigitalPinMap[pin] & 0x1F) / 16)
     #else
-      #define _PM_byteOffset(pin) (3 - (g_ADigitalPinMap[pin & 0x1F] / 8))
-    #endif
-
-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-      #define _PM_wordOffset(pin) (g_ADigitalPinMap[pin & 0x1F] / 16)
-    #else
-      #define _PM_wordOffset(pin) (1 - (g_ADigitalPinMap[pin & 0x1F] / 16))
+      #define _PM_byteOffset(pin) (3 - ((g_ADigitalPinMap[pin] & 0x1F) / 8))
+      #define _PM_wordOffset(pin) (1 - ((g_ADigitalPinMap[pin] & 0x1F) / 16))
     #endif
 
     // Because it's tied to a specific timer right now, there can be only
@@ -617,6 +610,8 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
       tc->TASKS_STOP = 1; // Stop timer
       return _PM_timerGetCount(tptr);
   }
+
+  #define _PM_minMinPeriod 1000
 
 #endif // NRF52_SERIES
 

--- a/arch.h
+++ b/arch.h
@@ -585,33 +585,39 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
       tc->PRESCALER   = 0; // 1:1 prescale (16 MHz)
       tc->INTENSET    = TIMER_INTENSET_COMPARE0_Enabled <<
                         TIMER_INTENSET_COMPARE0_Pos; // Event 0 interrupt
-      NVIC_DisableIRQ(timer[timerNum].IRQn);
-      NVIC_ClearPendingIRQ(timer[timerNum].IRQn);
-      NVIC_SetPriority(timer[timerNum].IRQn, 0); // Top priority
+      //NVIC_DisableIRQ(timer[timerNum].IRQn);
+      //NVIC_ClearPendingIRQ(timer[timerNum].IRQn);
+      //NVIC_SetPriority(timer[timerNum].IRQn, 0); // Top priority
       NVIC_EnableIRQ(timer[timerNum].IRQn);
   }
 
   inline void _PM_timerStart(void *tptr, uint32_t period) {
-      NRF_TIMER_Type *tc = (NRF_TIMER_Type *)tptr;
+      volatile NRF_TIMER_Type *tc = (volatile NRF_TIMER_Type *)tptr;
       tc->TASKS_STOP  = 1; // Stop timer
-      tc->TASKS_CLEAR = 1;
+      tc->TASKS_CLEAR = 1; // Reset to 0
       tc->CC[0]       = period;
       tc->TASKS_START = 1; // Start timer
   }
 
   inline uint32_t _PM_timerGetCount(void *tptr) {
-      NRF_TIMER_Type *tc = (NRF_TIMER_Type *)tptr;
+      volatile NRF_TIMER_Type *tc = (volatile NRF_TIMER_Type *)tptr;
       tc->TASKS_CAPTURE[0] = 1; // Capture timer to CC[n] register
       return tc->CC[0];
   }
 
   uint32_t _PM_timerStop(void *tptr) {
-      NRF_TIMER_Type *tc = (NRF_TIMER_Type *)tptr;
+      volatile NRF_TIMER_Type *tc = (volatile NRF_TIMER_Type *)tptr;
       tc->TASKS_STOP = 1; // Stop timer
-      return _PM_timerGetCount(tptr);
+      uint32_t count = _PM_timerGetCount(tptr);
+      // NOTE TO FUTURE SELF: I don't know why the GetCount code isn't
+      // working. It does the expected thing in a small test program but
+      // not here. I need to get on with testing on an actual matrix, so
+      // this is just a nonsense fudge value for now:
+      return 100;
+      //return count;
   }
 
-  #define _PM_minMinPeriod 25
+  #define _PM_minMinPeriod 100
 
 #endif // NRF52_SERIES
 

--- a/examples/doublebuffer/doublebuffer.ino
+++ b/examples/doublebuffer/doublebuffer.ino
@@ -42,14 +42,14 @@ PA06       PA14       PA22 SDA   PB06       PB14
 PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
 
 FEATHER nRF52840:
-P0.00      P0.08 D12   P0.24 RXD  P1.08 D5
-P0.01      P0.09       P0.25 TXD  P1.09 D13
-P0.02 A4   P0.10 D2    P0.26 D9   P1.10
-P0.03 A5   P0.11 SCL   P0.27 D10  P1.11
-P0.04 A0   P0.12 SDA   P0.28 A3   P1.12
-P0.05 A1   P0.13 MOSI  P0.29      P1.13
-P0.06 D11  P0.14 SCK   P0.30 A2   P1.14
-P0.07 D6   P0.15 MISO  P0.31      P1.15
+P0.00      P0.08 D12       P0.24 RXD  P1.08 D5
+P0.01      P0.09           P0.25 TXD  P1.09 D13
+P0.02 A4   P0.10 D2 (NFC)  P0.26 D9   P1.10
+P0.03 A5   P0.11 SCL       P0.27 D10  P1.11
+P0.04 A0   P0.12 SDA       P0.28 A3   P1.12
+P0.05 A1   P0.13 MOSI      P0.29      P1.13
+P0.06 D11  P0.14 SCK       P0.30 A2   P1.14
+P0.07 D6   P0.15 MISO      P0.31      P1.15
 
 RGB Matrix FeatherWing:
 R1  D6    A   A5
@@ -83,10 +83,10 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t oePin      = 5;
 #elif defined(NRF52_SERIES)
   uint8_t rgbPins[]  = {6, 11, A0, A1, A4, A5};
-  uint8_t addrPins[] = {2, 5, 12, 13};
-  uint8_t clockPin   = 9;
-  uint8_t latchPin   = 10;
-  uint8_t oePin      = A2;
+  uint8_t addrPins[] = {5, 9, 10, 13};
+  uint8_t clockPin   = 12;
+  uint8_t latchPin   = A2;
+  uint8_t oePin      = A3;
 #endif
 
 // Last arg here enables double-buffering

--- a/examples/doublebuffer/doublebuffer.ino
+++ b/examples/doublebuffer/doublebuffer.ino
@@ -41,6 +41,16 @@ PA05 A4    PA13       PA21 D7    PB05       PB13
 PA06       PA14       PA22 SDA   PB06       PB14
 PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
 
+FEATHER nRF52840:
+P0.00      P0.08 D12   P0.24 RXD  P1.08 D5
+P0.01      P0.09       P0.25 TXD  P1.09 D13
+P0.02 A4   P0.10 D2    P0.26 D9   P1.10
+P0.03 A5   P0.11 SCL   P0.27 D10  P1.11
+P0.04 A0   P0.12 SDA   P0.28 A3   P1.12
+P0.05 A1   P0.13 MOSI  P0.29      P1.13
+P0.06 D11  P0.14 SCK   P0.30 A2   P1.14
+P0.07 D6   P0.15 MISO  P0.31      P1.15
+
 RGB Matrix FeatherWing:
 R1  D6    A   A5
 G1  D5    B   A4
@@ -55,6 +65,7 @@ the code could run there (with some work to be done in the convert_*
 functions), but would be super RAM-inefficient. Should be fine on other
 M0 devices like a Metro, if wiring manually so one can pick a contiguous
 byte of PORT bits.
+RGB+clock are on different PORTs on nRF52840.
 */
 
 #if defined(__SAMD51__)
@@ -71,12 +82,11 @@ byte of PORT bits.
   uint8_t latchPin   = 4;
   uint8_t oePin      = 5;
 #elif defined(NRF52_SERIES)
-  // Use FeatherWing pinout
-  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
-  uint8_t addrPins[] = {A5, A4, A3, A2};
-  uint8_t clockPin   = 13;
-  uint8_t latchPin   = 0;
-  uint8_t oePin      = 1;
+  uint8_t rgbPins[]  = {6, 11, A0, A1, A4, A5};
+  uint8_t addrPins[] = {2, 5, 12, 13};
+  uint8_t clockPin   = 9;
+  uint8_t latchPin   = 10;
+  uint8_t oePin      = A2;
 #endif
 
 // Last arg here enables double-buffering

--- a/examples/doublebuffer/doublebuffer.ino
+++ b/examples/doublebuffer/doublebuffer.ino
@@ -75,7 +75,7 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t clockPin   = 13;
   uint8_t latchPin   = 0;
   uint8_t oePin      = 1;
-#else // SAMD21
+#elif defined(_SAMD21_)
   uint8_t rgbPins[]  = {6, 7, 10, 11, 12, 13};
   uint8_t addrPins[] = {0, 1, 2, 3};
   uint8_t clockPin   = SDA;

--- a/examples/protomatter/protomatter.ino
+++ b/examples/protomatter/protomatter.ino
@@ -41,6 +41,16 @@ PA05 A4    PA13       PA21 D7    PB05       PB13
 PA06       PA14       PA22 SDA   PB06       PB14
 PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
 
+FEATHER nRF52840:
+P0.00      P0.08 D12   P0.24 RXD  P1.08 D5
+P0.01      P0.09       P0.25 TXD  P1.09 D13
+P0.02 A4   P0.10 D2    P0.26 D9   P1.10
+P0.03 A5   P0.11 SCL   P0.27 D10  P1.11
+P0.04 A0   P0.12 SDA   P0.28 A3   P1.12
+P0.05 A1   P0.13 MOSI  P0.29      P1.13
+P0.06 D11  P0.14 SCK   P0.30 A2   P1.14
+P0.07 D6   P0.15 MISO  P0.31      P1.15
+
 RGB Matrix FeatherWing:
 R1  D6    A   A5
 G1  D5    B   A4
@@ -55,6 +65,7 @@ the code could run there (with some work to be done in the convert_*
 functions), but would be super RAM-inefficient. Should be fine on other
 M0 devices like a Metro, if wiring manually so one can pick a contiguous
 byte of PORT bits.
+RGB+clock are on different PORTs on nRF52840.
 */
 
 #if defined(__SAMD51__)
@@ -71,12 +82,11 @@ byte of PORT bits.
   uint8_t latchPin   = 4;
   uint8_t oePin      = 5;
 #elif defined(NRF52_SERIES)
-  // Use FeatherWing pinout
-  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
-  uint8_t addrPins[] = {A5, A4, A3, A2};
-  uint8_t clockPin   = 13;
-  uint8_t latchPin   = 0;
-  uint8_t oePin      = 1;
+  uint8_t rgbPins[]  = {6, 11, A0, A1, A4, A5};
+  uint8_t addrPins[] = {2, 5, 12, 13};
+  uint8_t clockPin   = 9;
+  uint8_t latchPin   = 10;
+  uint8_t oePin      = A2;
 #endif
 
 Adafruit_Protomatter matrix(

--- a/examples/protomatter/protomatter.ino
+++ b/examples/protomatter/protomatter.ino
@@ -42,14 +42,14 @@ PA06       PA14       PA22 SDA   PB06       PB14
 PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
 
 FEATHER nRF52840:
-P0.00      P0.08 D12   P0.24 RXD  P1.08 D5
-P0.01      P0.09       P0.25 TXD  P1.09 D13
-P0.02 A4   P0.10 D2    P0.26 D9   P1.10
-P0.03 A5   P0.11 SCL   P0.27 D10  P1.11
-P0.04 A0   P0.12 SDA   P0.28 A3   P1.12
-P0.05 A1   P0.13 MOSI  P0.29      P1.13
-P0.06 D11  P0.14 SCK   P0.30 A2   P1.14
-P0.07 D6   P0.15 MISO  P0.31      P1.15
+P0.00      P0.08 D12       P0.24 RXD  P1.08 D5
+P0.01      P0.09           P0.25 TXD  P1.09 D13
+P0.02 A4   P0.10 D2 (NFC)  P0.26 D9   P1.10
+P0.03 A5   P0.11 SCL       P0.27 D10  P1.11
+P0.04 A0   P0.12 SDA       P0.28 A3   P1.12
+P0.05 A1   P0.13 MOSI      P0.29      P1.13
+P0.06 D11  P0.14 SCK       P0.30 A2   P1.14
+P0.07 D6   P0.15 MISO      P0.31      P1.15
 
 RGB Matrix FeatherWing:
 R1  D6    A   A5
@@ -83,10 +83,10 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t oePin      = 5;
 #elif defined(NRF52_SERIES)
   uint8_t rgbPins[]  = {6, 11, A0, A1, A4, A5};
-  uint8_t addrPins[] = {2, 5, 12, 13};
-  uint8_t clockPin   = 9;
-  uint8_t latchPin   = 10;
-  uint8_t oePin      = A2;
+  uint8_t addrPins[] = {5, 9, 10, 13};
+  uint8_t clockPin   = 12;
+  uint8_t latchPin   = A2;
+  uint8_t oePin      = A3;
 #endif
 
 Adafruit_Protomatter matrix(


### PR DESCRIPTION
Pinout is NOT compatible with RGB matrix FeatherWing. Also, there’s a hardcoded constant in arch.h that will eventually need to be resolved.