### PR TITLE
Port  to stm32f405

### DIFF
--- a/arch.h
+++ b/arch.h
@@ -1133,4 +1133,8 @@ void _PM_swapbuffer_maybe(Protomatter_core *core) {
 
 #endif // ARDUINO || CIRCUITPYTHON
 
+#ifndef _PM_PORT_TYPE
+#define _PM_PORT_TYPE uint32_t
+#endif
+
 #endif // _PROTOMATTER_ARCH_H_

--- a/arch.h
+++ b/arch.h
@@ -189,8 +189,8 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
     #define _PM_pinLow(pin)           gpio_set_pin_level(pin, 0)
     #define _PM_portBitMask(pin)      (1u << ((pin) % 32))
 
-    #define _PM_byteOffset(pin) ((pin) / 8)
-    #define _PM_wordOffset(pin) ((pin) / 16)
+    #define _PM_byteOffset(pin) ((pin % 32) / 8)
+    #define _PM_wordOffset(pin) ((pin % 32) / 16)
 
     #if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
     #error  SRSLY
@@ -627,8 +627,8 @@ _PM_minMinPeriod:            Mininum value for the "minPeriod" class member,
     #define _PM_pinLow(pin)           nrf_gpio_pin_clear(pin)
     #define _PM_portBitMask(pin)      (1u << ((pin) % 32))
 
-    #define _PM_byteOffset(pin) ((pin) / 8)
-    #define _PM_wordOffset(pin) ((pin) / 16)
+    #define _PM_byteOffset(pin) ((pin % 32) / 8)
+    #define _PM_wordOffset(pin) ((pin % 32) / 16)
 
     #if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
     #error  SRSLY

--- a/core.h
+++ b/core.h
@@ -23,8 +23,8 @@ typedef enum {
 // RGB data but do NOT need the set or clear registers, so those items
 // are also declared as separate things in the core structure that follows.
 typedef struct {
-    volatile uint32_t *setReg;          // GPIO bit set register
-    volatile uint32_t *clearReg;        // GPIO bit clear register
+    volatile void *setReg;              // GPIO bit set register
+    volatile void *clearReg;            // GPIO bit clear register
     uint32_t           bit;             // GPIO bitmask
     uint8_t            pin;             // Some identifier, e.g. Arduino pin #
 } _PM_pin;
@@ -48,7 +48,7 @@ typedef struct {
     void              *rgbMask;         // PORT bit mask for each RGB pin
     uint32_t           clockMask;       // PORT bit mask for RGB clock
     uint32_t           rgbAndClockMask; // PORT bit mask for RGB data + clock
-    volatile uint32_t *addrPortToggle;  // See singleAddrPort below
+    volatile void     *addrPortToggle;  // See singleAddrPort below
     void              *screenData;      // Per-bitplane RGB data for matrix
     _PM_pin            latch;           // RGB data latch
     _PM_pin            oe;              // !OE (LOW out enable)


### PR DESCRIPTION
Testing performed: with an adapted simpele_scroller demo, all the expected pins change in plausible ways.  I didn't breadboard/proto up an adapter yet.  To be followed with a CircuitPython PR.

```
matrix = rgbmatrix.RGBMatrix(
    width=64, height=32, bit_depth=4,
    rgb_pins=[board.D13, board.D12, board.D11, board.A4, board.A5, board.D6],
    addr_pins=[board.A0, board.A1, board.A2, board.A3],
    clock_pin=board.D5, latch_pin=board.D9, output_enable_pin=board.D10, doublebuffer=False)
```