### PR TITLE
fix circuitpython build error

### DIFF
--- a/arch.h
+++ b/arch.h
@@ -20,6 +20,8 @@
 #if !defined(_PROTOMATTER_ARCH_H_)
 #define _PROTOMATTER_ARCH_H_
 
+#include <string.h>
+
 /*
 Common ground for architectures to support this library:
 


### PR DESCRIPTION
In a51676db5e63 ("clang-format the lot"), headers were re-ordered. This is not a change that makes no difference, and caused CircuitPython to stop building:
```
../../lib/protomatter/arch.h: In function '_PM_convert_565_word':
../../lib/protomatter/arch.h:1114:3: error: implicit declaration of function 'memset' [-Werror=implicit-function-declaration]
 1114 |   memset(dest, 0, core->bufferSize);
      |   ^~~~~~
../../lib/protomatter/arch.h:1114:3: error: incompatible implicit declaration of built-in function 'memset' [-Werror]
../../lib/protomatter/arch.h:147:1: note: include '<string.h>' or provide a declaration of 'memset'
```
However, the real fix is to include in arch.h any header that MUST have its declarations visible for the header to be self-supporting; do so.