### PR TITLE
ESP32 support, tested, works

### DIFF
--- a/Adafruit_Protomatter.cpp
+++ b/Adafruit_Protomatter.cpp
@@ -70,7 +70,8 @@ Adafruit_Protomatter::Adafruit_Protomatter(uint16_t bitWidth, uint8_t bitDepth,
                                            uint8_t clockPin, uint8_t latchPin,
                                            uint8_t oePin, bool doubleBuffer,
                                            void *timer)
-    : GFXcanvas16(bitWidth, (2 << min(addrCount, 5)) * min(rgbCount, 5)) {
+    : GFXcanvas16(bitWidth,
+                  (2 << min((int)addrCount, 5)) * min((int)rgbCount, 5)) {
   if (bitDepth > 6)
     bitDepth = 6; // GFXcanvas16 color limit (565)
 

--- a/core.c
+++ b/core.c
@@ -428,7 +428,15 @@ void _PM_free(Protomatter_core *core) {
 }
 
 // ISR function (in arch.h) calls this function which it extern'd.
-void _PM_row_handler(Protomatter_core *core) {
+// Profuse apologies for the ESP32-specific IRAM_ATTR here -- the goal was
+// for all architecture-specific detauls to be in arch.h -- but the need
+// for one here caught me off guard. So, in arch.h, for all non-ESP32
+// devices, IRAM_ATTR is defined to nothing and is ignored here. If any
+// future architectures have their own attribute for making a function
+// RAM-resident, #define IRAM_ATTR to that in the corresponding device-
+// specific section of arch.h. Sorry. :/
+// Any functions called by this function should also be IRAM_ATTR'd.
+IRAM_ATTR void _PM_row_handler(Protomatter_core *core) {
 
   _PM_setReg(core->oe); // Disable LED output
 
@@ -586,7 +594,7 @@ void _PM_row_handler(Protomatter_core *core) {
 // function, too often ends in disaster...but must be vigilant in the
 // three-function maintenance then.)
 
-static void blast_byte(Protomatter_core *core, uint8_t *data) {
+IRAM_ATTR static void blast_byte(Protomatter_core *core, uint8_t *data) {
 #if defined(_PM_portToggleRegister)
   // If here, it was established in begin() that the RGB data bits and
   // clock are all within the same byte of a PORT register, else we'd be
@@ -626,7 +634,7 @@ static void blast_byte(Protomatter_core *core, uint8_t *data) {
 #endif
 }
 
-static void blast_word(Protomatter_core *core, uint16_t *data) {
+IRAM_ATTR static void blast_word(Protomatter_core *core, uint16_t *data) {
 #if defined(_PM_portToggleRegister)
   // See notes above -- except now 16-bit word in PORT.
   volatile uint16_t *toggle =
@@ -652,7 +660,7 @@ static void blast_word(Protomatter_core *core, uint16_t *data) {
 #endif
 }
 
-static void blast_long(Protomatter_core *core, uint32_t *data) {
+IRAM_ATTR static void blast_long(Protomatter_core *core, uint32_t *data) {
 #if defined(_PM_portToggleRegister)
   // See notes above -- except now full 32-bit PORT.
   volatile uint32_t *toggle = (volatile uint32_t *)core->toggleReg;

--- a/examples/doublebuffer/doublebuffer.ino
+++ b/examples/doublebuffer/doublebuffer.ino
@@ -51,6 +51,16 @@ P0.05 A1   P0.13 MOSI      P0.29      P1.13
 P0.06 D11  P0.14 SCK       P0.30 A2   P1.14
 P0.07 D6   P0.15 MISO      P0.31      P1.15
 
+FEATHER ESP32:
+P0.00          P0.08          P0.16 16/RX    P0.24          P1.00 32/A7
+P0.01          P0.09          P0.17 17/TX    P0.25 25/A1    P1.01 33/A9/SS
+P0.02          P0.10          P0.18 18/MOSI  P0.26 26/A0    P1.02 34/A2 (in)
+P0.03          P0.11          P0.19 19/MISO  P0.27 27/A10   P1.03
+P0.04 4/A5     P0.12 12/A11   P0.20          P0.28          P1.04 36/A4 (in)
+P0.05 5/SCK    P0.13 13/A12   P0.21 21       P0.29          P1.05
+P0.06          P0.14 14/A6    P0.22 22/SCL   P0.30          P1.06
+P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3 (in)
+
 RGB Matrix FeatherWing:
 R1  D6    A   A5
 G1  D5    B   A4
@@ -87,6 +97,16 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t clockPin   = 12;
   uint8_t latchPin   = A2;
   uint8_t oePin      = A3;
+#elif defined(ESP32)
+  // 'Safe' pins (not overlapping any peripherals):
+  // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
+  // Peripheral-overlapping pins, sorted from 'most expendible':
+  // 16, 17 (RX, TX), 25, 26 (A0, A1), 18, 5, 9 (MOSI, SCK, MISO), 22, 23 (SCL, SDA)
+  uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
+  uint8_t addrPins[] = {16, 17, 25, 26};
+  uint8_t clockPin   = 27; // Must be on same port as rgbPins
+  uint8_t latchPin   = 32;
+  uint8_t oePin      = 33;
 #endif
 
 // Last arg here enables double-buffering

--- a/examples/protomatter/protomatter.ino
+++ b/examples/protomatter/protomatter.ino
@@ -51,6 +51,16 @@ P0.05 A1   P0.13 MOSI      P0.29      P1.13
 P0.06 D11  P0.14 SCK       P0.30 A2   P1.14
 P0.07 D6   P0.15 MISO      P0.31      P1.15
 
+FEATHER ESP32:
+P0.00          P0.08          P0.16 16/RX    P0.24          P1.00 32/A7
+P0.01          P0.09          P0.17 17/TX    P0.25 25/A1    P1.01 33/A9/SS
+P0.02          P0.10          P0.18 18/MOSI  P0.26 26/A0    P1.02 34/A2
+P0.03          P0.11          P0.19 19/MISO  P0.27 27/A10   P1.03
+P0.04 4/A5     P0.12 12/A11   P0.20          P0.28          P1.04 36/A4
+P0.05 5/SCK    P0.13 13/A12   P0.21 21       P0.29          P1.05
+P0.06          P0.14 14/A6    P0.22 22/SCL   P0.30          P1.06
+P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3
+
 RGB Matrix FeatherWing:
 R1  D6    A   A5
 G1  D5    B   A4
@@ -87,6 +97,12 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t clockPin   = 12;
   uint8_t latchPin   = A2;
   uint8_t oePin      = A3;
+#elif defined(ESP32)
+  uint8_t rgbPins[]  = {A5, 14, 15, 27, 21, 12};
+  uint8_t addrPins[] = {A7, A4, A3, A2};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 16; // RX
+  uint8_t oePin      = 17; // TX
 #endif
 
 Adafruit_Protomatter matrix(

--- a/examples/protomatter/protomatter.ino
+++ b/examples/protomatter/protomatter.ino
@@ -54,12 +54,12 @@ P0.07 D6   P0.15 MISO      P0.31      P1.15
 FEATHER ESP32:
 P0.00          P0.08          P0.16 16/RX    P0.24          P1.00 32/A7
 P0.01          P0.09          P0.17 17/TX    P0.25 25/A1    P1.01 33/A9/SS
-P0.02          P0.10          P0.18 18/MOSI  P0.26 26/A0    P1.02 34/A2
+P0.02          P0.10          P0.18 18/MOSI  P0.26 26/A0    P1.02 34/A2 (in)
 P0.03          P0.11          P0.19 19/MISO  P0.27 27/A10   P1.03
-P0.04 4/A5     P0.12 12/A11   P0.20          P0.28          P1.04 36/A4
+P0.04 4/A5     P0.12 12/A11   P0.20          P0.28          P1.04 36/A4 (in)
 P0.05 5/SCK    P0.13 13/A12   P0.21 21       P0.29          P1.05
 P0.06          P0.14 14/A6    P0.22 22/SCL   P0.30          P1.06
-P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3
+P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3 (in)
 
 RGB Matrix FeatherWing:
 R1  D6    A   A5
@@ -98,11 +98,15 @@ RGB+clock are on different PORTs on nRF52840.
   uint8_t latchPin   = A2;
   uint8_t oePin      = A3;
 #elif defined(ESP32)
-  uint8_t rgbPins[]  = {A5, 14, 15, 27, 21, 12};
-  uint8_t addrPins[] = {A7, A4, A3, A2};
-  uint8_t clockPin   = 13;
-  uint8_t latchPin   = 16; // RX
-  uint8_t oePin      = 17; // TX
+  // 'Safe' pins (not overlapping any peripherals):
+  // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
+  // Peripheral-overlapping pins, sorted from 'most expendible':
+  // 16, 17 (RX, TX), 25, 26 (A0, A1), 18, 5, 9 (MOSI, SCK, MISO), 22, 23 (SCL, SDA)
+  uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
+  uint8_t addrPins[] = {16, 17, 25, 26};
+  uint8_t clockPin   = 27;
+  uint8_t latchPin   = 32;
+  uint8_t oePin      = 33;
 #endif
 
 Adafruit_Protomatter matrix(

--- a/examples/protomatter/protomatter.ino
+++ b/examples/protomatter/protomatter.ino
@@ -104,7 +104,7 @@ RGB+clock are on different PORTs on nRF52840.
   // 16, 17 (RX, TX), 25, 26 (A0, A1), 18, 5, 9 (MOSI, SCK, MISO), 22, 23 (SCL, SDA)
   uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
   uint8_t addrPins[] = {16, 17, 25, 26};
-  uint8_t clockPin   = 27;
+  uint8_t clockPin   = 27; // Must be on same port as rgbPins
   uint8_t latchPin   = 32;
   uint8_t oePin      = 33;
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=Adafruit Protomatter
-version=1.0.0
+version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit RGB LED matrix.
 paragraph=RGB LED matrix.
 category=Display
 url=https://github.com/adafruit/Adafruit_protomatter
-architectures=samd,nrf52,stm32
+architectures=samd,nrf52,stm32,esp32
 depends=Adafruit GFX Library


### PR DESCRIPTION
Use GPIOs 0-33; 34 and above are input-only. Use GPIOs 0-31 for RGB + clock, ideally all within the same 8-bit grouping for best RAM usage. On the Feather ESP32 that would knock out most of the major peripherals, so the examples favor sloppy RAM use in order to keep SPI & I2C available (but Serial and DACs are not, can swap for a different peripheral if needed).