### PR TITLE
STM32: switch to timer allocator

### DIFF
--- a/arch.h
+++ b/arch.h
@@ -1226,12 +1226,14 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
     dest += core->bufferSize * (1 - core->activeBuffer);
   }
 
-#if defined(_PM_portToggleRegister) && !defined(_PM_STRICT_32BIT_IO)
+#if defined(_PM_portToggleRegister)
+#if !defined(_PM_STRICT_32BIT_IO)
   // core->clockMask mask is already an 8-bit value
   uint8_t clockMask = core->clockMask;
 #else
   // core->clockMask mask is 32-bit, shift down to 8-bit for this func.
   uint8_t clockMask = core->clockMask >> (core->portOffset * 8);
+#endif
 #endif
 
   // No need to clear matrix buffer, loops below do a full overwrite

--- a/core.c
+++ b/core.c
@@ -541,8 +541,8 @@ IRAM_ATTR void _PM_row_handler(Protomatter_core *core) {
 
   // Set timer and enable LED output for data loaded on PRIOR pass:
   _PM_timerStart(core->timer, core->bitZeroPeriod << prevPlane);
-  delayMicroseconds(1);   // Appease Teensy4
-  _PM_clearReg(core->oe); // Enable LED output
+  _PM_delayMicroseconds(1); // Appease Teensy4
+  _PM_clearReg(core->oe);   // Enable LED output
 
   uint32_t elementsPerLine =
       _PM_chunkSize * ((core->width + (_PM_chunkSize - 1)) / _PM_chunkSize);


### PR DESCRIPTION
This PR changes the Circuitpython STM32 methods to use the new timer allocator system, allowing RGBMatrix to dynamically select out of an available pool of timers rather than being hard-coded to the TIM6 basic timer.

Also resolves #15