### PR TITLE
_PM_stop: Don't HardFault when _PM_begin failed

### DIFF
--- a/core.c
+++ b/core.c
@@ -383,6 +383,11 @@ ProtomatterStatus _PM_begin(Protomatter_core *core) {
 // so it won't halt with lit LEDs.
 void _PM_stop(Protomatter_core *core) {
   if ((core)) {
+    // If _PM_begin failed, this will be a NULL pointer.  Stop early,
+    // none of the other "stop" operations make sense
+    if (!core->screenData) {
+       return;
+    }
     while (core->swapBuffers)
       ;                         // Wait for any pending buffer swap
     _PM_timerStop(core->timer); // Halt timer


### PR DESCRIPTION
When _PM_begin fails, it leaves the object in a partially-uninitialized state.  To recover any allocated storage, we need to call _PM_free; but if the allocation of core->screenData failed, then other internal pointers such as core->oe.setReg are not set, and the actions in _PM_stop will cause a HardFault.

This is a partial fix for adafruit/circuitpython#3184.  Additional changes (aside from merely updating the submodule) are required in CircuitPython.