### PR TITLE
github actions: fix CI by requesting python verson 3.9

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
this is the same fix used in Adafruit_Learning_System_Guides
