### PR TITLE
Add chaining of two matrices into a square

### DIFF
--- a/examples/simplechain/simplechain.ino
+++ b/examples/simplechain/simplechain.ino
@@ -1,0 +1,272 @@
+/* ----------------------------------------------------------------------
+"Simple" Protomatter library example sketch (once you get past all
+the various pin configurations at the top, and all the comments).
+Shows basic use of Adafruit_Protomatter library with different devices.
+
+This example is written for two 64x32 matricies chained together. The 
+second matrix is rotated clockwise to sit on top of the first making
+a 64x64 square.
+
+Once the RGB matrix is initialized, most functions of the Adafruit_GFX
+library are available for drawing -- code from other projects that use
+LCDs or OLEDs can be easily adapted, or may be insightful for reference.
+GFX library is documented here:
+https://learn.adafruit.com/adafruit-gfx-graphics-library
+------------------------------------------------------------------------- */
+
+#include <Adafruit_Protomatter_Chain.h>
+
+/* ----------------------------------------------------------------------
+The RGB matrix must be wired to VERY SPECIFIC pins, different for each
+microcontroller board. This first section sets that up for a number of
+supported boards. Notes have been moved to the bottom of the code.
+------------------------------------------------------------------------- */
+
+#if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
+  uint8_t rgbPins[]  = {7, 8, 9, 10, 11, 12};
+  uint8_t addrPins[] = {17, 18, 19, 20};
+  uint8_t clockPin   = 14;
+  uint8_t latchPin   = 15;
+  uint8_t oePin      = 16;
+#elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 0;
+  uint8_t oePin      = 1;
+#elif defined(__SAMD51__) // M4 Metro Variants (Express, AirLift)
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 0;
+  uint8_t oePin      = 1;
+#elif defined(_SAMD21_) // Feather M0 variants
+  uint8_t rgbPins[]  = {6, 7, 10, 11, 12, 13};
+  uint8_t addrPins[] = {0, 1, 2, 3};
+  uint8_t clockPin   = SDA;
+  uint8_t latchPin   = 4;
+  uint8_t oePin      = 5;
+#elif defined(NRF52_SERIES) // Special nRF52840 FeatherWing pinout
+  uint8_t rgbPins[]  = {6, A5, A1, A0, A4, 11};
+  uint8_t addrPins[] = {10, 5, 13, 9};
+  uint8_t clockPin   = 12;
+  uint8_t latchPin   = PIN_SERIAL1_RX;
+  uint8_t oePin      = PIN_SERIAL1_TX;
+#elif defined(ESP32)
+  // 'Safe' pins, not overlapping any peripherals:
+  // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
+  // Peripheral-overlapping pins, sorted from 'most expendible':
+  // 16, 17 (RX, TX)
+  // 25, 26 (A0, A1)
+  // 18, 5, 9 (MOSI, SCK, MISO)
+  // 22, 23 (SCL, SDA)
+  uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
+  uint8_t addrPins[] = {16, 17, 25, 26};
+  uint8_t clockPin   = 27; // Must be on same port as rgbPins
+  uint8_t latchPin   = 32;
+  uint8_t oePin      = 33;
+#elif defined(ARDUINO_TEENSY40)
+  uint8_t rgbPins[]  = {15, 16, 17, 20, 21, 22}; // A1-A3, A6-A8, skip SDA,SCL
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#elif defined(ARDUINO_TEENSY41)
+  uint8_t rgbPins[]  = {26, 27, 38, 20, 21, 22}; // A12-14, A6-A8
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#endif
+
+/* ----------------------------------------------------------------------
+Okay, here's where the RGB LED matrix is actually declared...
+
+First two arguments are the display width and height in pixels.
+Usually 64 x 64.
+
+The third argument is the matrix width, in pixels. Usually 128 for
+two matricies, but might go larger if you're chaining even more 
+matrices.
+
+Forth argument is the "bit depth," which determines color
+fidelity, applied to red, green and blue (e.g. "4" here means
+4 bits red, 4 green, 4 blue = 2^4 x 2^4 x 2^4 = 4096 colors).
+There is a trade-off between bit depth and RAM usage. Most
+programs will tend to use either 1 (R,G,B on/off, 8 colors,
+best for text, LED sand, etc.) or the maximum of 6 (best for
+shaded images...though, because the GFX library was designed
+for LCDs, only 5 of those bits are available for red and blue.
+
+Fifth argument is the number of concurrent (parallel) matrix
+outputs. THIS SHOULD ALWAYS BE "1" FOR NOW. Fourth is a uint8_t
+array listing six pins: red, green and blue data out for the
+top half of the display, and same for bottom half. There are
+hard constraints as to which pins can be used -- they must all
+be on the same PORT register, ideally all within the same byte
+of that PORT.
+
+Sixth argument is the number of "address" (aka row select) pins,
+from which the matrix height is inferred. "4" here means four
+address lines, matrix height is then (2 x 2^4) = 32 pixels.
+16-pixel-tall matrices will have 3 pins here, 32-pixel will have
+4, 64-pixel will have 5. Sixth argument is a uint8_t array
+listing those pin numbers. No PORT constraints here.
+
+Next three arguments are pin numbers for other RGB matrix
+control lines: clock, latch and output enable (active low).
+Clock pin MUST be on the same PORT register as RGB data pins
+(and ideally in same byte). Other pins have no special rules.
+
+Last argument is a boolean (true/false) to enable double-
+buffering for smooth animation (requires 2X the RAM). See the
+"doublebuffer" example for a demonstration.
+------------------------------------------------------------------------- */
+
+Adafruit_Protomatter_Chain matrix(
+  64,          // Display width
+  64,          // Display height
+  128,         // Width of all the matrices in pixels
+  4,           // Bit depth, 1-6
+  1, rgbPins,  // # of matrix chains, array of 6 RGB pins for each
+  4, addrPins, // # of address pins (height is inferred), array of pins
+  clockPin, latchPin, oePin, // Other matrix control pins
+  false);      // No double-buffering here (see "doublebuffer" example)
+
+// SETUP - RUNS ONCE AT PROGRAM START --------------------------------------
+
+void setup(void) {
+  Serial.begin(9600);
+
+  // Initialize matrix...
+  ProtomatterStatus status = matrix.begin();
+  Serial.print("Protomatter begin() status: ");
+  Serial.println((int)status);
+  if(status != PROTOMATTER_OK) {
+    // DO NOT CONTINUE if matrix setup encountered an error.
+    for(;;);
+  }
+
+  // Since this is a simple program with no animation, all the
+  // drawing can be done here in setup() rather than loop():
+
+  // Make four color bars (red, green, blue, white) with brightness ramp:
+  for(int x=0; x<matrix.width(); x++) {
+    uint8_t level = x * 256 / matrix.width(); // 0-255 brightness
+    matrix.drawPixel(x, matrix.height() - 4, matrix.color565(level, 0, 0));
+    matrix.drawPixel(x, matrix.height() - 3, matrix.color565(0, level, 0));
+    matrix.drawPixel(x, matrix.height() - 2, matrix.color565(0, 0, level));
+    matrix.drawPixel(x, matrix.height() - 1,
+                     matrix.color565(level, level, level));
+  }
+  // You'll notice the ramp looks smoother as bit depth increases
+  // (second argument to the matrix constructor call above setup()).
+
+  // Simple shapes and text, showing GFX library calls:
+  matrix.drawCircle(12, 10, 9, matrix.color565(255, 0, 0));
+  matrix.drawRect(14, 6, 17, 17, matrix.color565(0, 255, 0));
+  matrix.drawTriangle(32, 9, 41, 27, 23, 27, matrix.color565(0, 0, 255));
+  matrix.println("ADAFRUIT"); // Default text color is white
+
+  // AFTER DRAWING, A show() CALL IS REQUIRED TO UPDATE THE MATRIX!
+
+  matrix.show(); // Copy data to matrix buffers
+}
+
+// LOOP - RUNS REPEATEDLY AFTER SETUP --------------------------------------
+
+void loop(void) {
+  // Since there's nothing more to be drawn, this loop() function just
+  // shows the approximate refresh rate of the matrix at current settings.
+  Serial.print("Refresh FPS = ~");
+  Serial.println(matrix.getFrameCount());
+  delay(1000);
+}
+
+// MORE NOTES --------------------------------------------------------------
+
+/*
+The "RGB and clock bits on same PORT register" constraint requires
+considerable planning and knowledge of the underlying microcontroller
+hardware. These are some earlier notes on various devices' PORT registers
+and bits and their corresponding Arduino pin numbers. You probably won't
+need this -- it's all codified in the #if defined() sections at the top
+of this sketch now -- but keeping it around for reference if needed.
+
+METRO M0 PORT-TO-PIN ASSIGNMENTS BY BYTE:
+PA00       PA08 D4    PA16 D11   PB00       PB08 A1
+PA01       PA09 D3    PA17 D13   PB01       PB09 A2
+PA02 A0    PA10 D1    PA18 D10   PB02 A5    PB10 MOSI
+PA03       PA11 D0    PA19 D12   PB03       PB11 SCK
+PA04 A3    PA12 MISO  PA20 D6    PB04       PB12
+PA05 A4    PA13       PA21 D7    PB05       PB13
+PA06 D8    PA14 D2    PA22 SDA   PB06       PB14
+PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
+
+SAME, METRO M4:
+PA00       PA08       PA16 D13   PB00       PB08 A4    PB16 D3
+PA01       PA09       PA17 D12   PB01       PB09 A5    PB17 D2
+PA02 A0    PA10       PA18 D10   PB02 SDA   PB10       PB18
+PA03       PA11       PA19 D11   PB03 SCL   PB11       PB19
+PA04 A3    PA12 MISO  PA20 D9    PB04       PB12 D7    PB20
+PA05 A1    PA13 SCK   PA21 D8    PB05       PB13 D4    PB21
+PA06 A2    PA14 MISO  PA22 D1    PB06       PB14 D5    PB22
+PA07       PA15       PA23 D0    PB07       PB15 D6    PB23
+
+FEATHER M4:
+PA00       PA08       PA16 D5    PB08 A2    PB16 D1/TX
+PA01       PA09       PA17 SCK   PB09 A3    PB17 D0/RX
+PA02 A0    PA10       PA18 D6    PB10       PB18
+PA03       PA11       PA19 D9    PB11       PB19
+PA04 A4    PA12 SDA   PA20 D10   PB12       PB20
+PA05 A1    PA13 SCL   PA21 D11   PB13       PB21
+PA06 A5    PA14 D4    PA22 D12   PB14       PB22 MISO
+PA07       PA15       PA23 D13   PB15       PB23 MOSI
+
+FEATHER M0:
+PA00       PA08       PA16 D11   PB00       PB08 A1
+PA01       PA09       PA17 D13   PB01       PB09 A2
+PA02 A0    PA10 TX/D1 PA18 D10   PB02 A5    PB10 MOSI
+PA03       PA11 RX/D0 PA19 D12   PB03       PB11 SCK
+PA04 A3    PA12 MISO  PA20 D6    PB04       PB12
+PA05 A4    PA13       PA21 D7    PB05       PB13
+PA06       PA14       PA22 SDA   PB06       PB14
+PA07 D9    PA15 D5    PA23 SCL   PB07       PB15
+
+FEATHER nRF52840:
+P0.00      P0.08 D12       P0.24 RXD  P1.08 D5
+P0.01      P0.09           P0.25 TXD  P1.09 D13
+P0.02 A4   P0.10 D2 (NFC)  P0.26 D9   P1.10
+P0.03 A5   P0.11 SCL       P0.27 D10  P1.11
+P0.04 A0   P0.12 SDA       P0.28 A3   P1.12
+P0.05 A1   P0.13 MOSI      P0.29      P1.13
+P0.06 D11  P0.14 SCK       P0.30 A2   P1.14
+P0.07 D6   P0.15 MISO      P0.31      P1.15
+
+FEATHER ESP32:
+P0.00          P0.08          P0.16 16/RX    P0.24          P1.00 32/A7
+P0.01          P0.09          P0.17 17/TX    P0.25 25/A1    P1.01 33/A9/SS
+P0.02          P0.10          P0.18 18/MOSI  P0.26 26/A0    P1.02 34/A2 (in)
+P0.03          P0.11          P0.19 19/MISO  P0.27 27/A10   P1.03
+P0.04 4/A5     P0.12 12/A11   P0.20          P0.28          P1.04 36/A4 (in)
+P0.05 5/SCK    P0.13 13/A12   P0.21 21       P0.29          P1.05
+P0.06          P0.14 14/A6    P0.22 22/SCL   P0.30          P1.06
+P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3 (in)
+
+RGB MATRIX FEATHERWING NOTES:
+R1  D6    A   A5
+G1  D5    B   A4
+B1  D9    C   A3
+R2  D11   D   A2
+G2  D10   LAT D0/RX
+B2  D12   OE  D1/TX
+CLK D13
+RGB+clock fit in one PORT byte on Feather M4!
+RGB+clock are on same PORT but not within same byte on Feather M0 --
+the code could run there, but would be super RAM-inefficient. Avoid.
+Should be fine on other M0 devices like a Metro, if wiring manually
+so one can pick a contiguous byte of PORT bits.
+Original RGB Matrix FeatherWing will NOT work on Feather nRF52840
+because RGB+clock are on different PORTs. This was resolved by making
+a unique version of the FeatherWing that works with that board!
+*/

--- a/src/Adafruit_Protomatter_Chain.cpp
+++ b/src/Adafruit_Protomatter_Chain.cpp
@@ -43,21 +43,18 @@
 
 extern Protomatter_core *_PM_protoPtr; ///< In core.c (via arch.h)
 
-Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth,
-                                                       uint8_t rgbCount, uint8_t *rgbList,
-                                                       uint8_t addrCount, uint8_t *addrList,
-                                                       uint8_t clockPin, uint8_t latchPin,
-                                                       uint8_t oePin, bool doubleBuffer,
-                                                       void *timer)
-    : GFXcanvas16(displayWidth, displayHeight)
-{
+Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(
+    uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth,
+    uint8_t bitDepth, uint8_t rgbCount, uint8_t *rgbList, uint8_t addrCount,
+    uint8_t *addrList, uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
+    bool doubleBuffer, void *timer)
+    : GFXcanvas16(displayWidth, displayHeight) {
   if (bitDepth > 6)
     bitDepth = 6; // GFXcanvas16 color limit (565)
 
   bWidth = bitWidth;
   uint32_t bytes = displayWidth * displayHeight * 2;
-  if ((correctedBuffer = (uint16_t *)malloc(bytes)))
-  {
+  if ((correctedBuffer = (uint16_t *)malloc(bytes))) {
     memset(correctedBuffer, 0, bytes);
   }
 
@@ -70,16 +67,14 @@ Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(uint16_t displayWidth, ui
                  addrList, clockPin, latchPin, oePin, doubleBuffer, timer);
 }
 
-Adafruit_Protomatter_Chain::~Adafruit_Protomatter_Chain(void)
-{
+Adafruit_Protomatter_Chain::~Adafruit_Protomatter_Chain(void) {
   _PM_deallocate(&core);
   _PM_protoPtr = NULL;
   if (correctedBuffer)
     free(correctedBuffer);
 }
 
-ProtomatterStatus Adafruit_Protomatter_Chain::begin(void)
-{
+ProtomatterStatus Adafruit_Protomatter_Chain::begin(void) {
   _PM_protoPtr = &core;
   return _PM_begin(&core);
 }
@@ -87,15 +82,13 @@ ProtomatterStatus Adafruit_Protomatter_Chain::begin(void)
 // Transfer data from GFXcanvas16 to the matrix framebuffer's weird
 // internal format. The actual conversion functions referenced below
 // are in core.c, reasoning is explained there.
-void Adafruit_Protomatter_Chain::show(void)
-{
+void Adafruit_Protomatter_Chain::show(void) {
   correctBuffer();
   _PM_convert_565(&core, correctedBuffer, bWidth);
   _PM_swapbuffer_maybe(&core);
 }
 
-void Adafruit_Protomatter_Chain::correctBuffer()
-{
+void Adafruit_Protomatter_Chain::correctBuffer() {
   int16_t displayWidth = width();
   int16_t displayHeight = height();
 
@@ -105,15 +98,16 @@ void Adafruit_Protomatter_Chain::correctBuffer()
 
   // Loop through the entire display
   // Map the pixels from the display to the correct pixels on the matricies
-  for (int row = 0; row < (displayHeight / 2); row++)
-  {
-    for (int col = 0; col < displayWidth; col++)
-    {
+  for (int row = 0; row < (displayHeight / 2); row++) {
+    for (int col = 0; col < displayWidth; col++) {
       uint16_t *upperSource = upperdisplay + (row * displayWidth) + col;
       uint16_t *lowerSource = lowerdisplay + (row * displayWidth) + col;
 
-      uint16_t *upperDest = correctedBuffer + ((displayHeight / 2 - row) * displayWidth * 2) - (displayWidth + col + 1);
-      uint16_t *lowerDest = correctedBuffer + (2 * row * displayWidth) + displayWidth + col;
+      uint16_t *upperDest = correctedBuffer +
+                            ((displayHeight / 2 - row) * displayWidth * 2) -
+                            (displayWidth + col + 1);
+      uint16_t *lowerDest =
+          correctedBuffer + (2 * row * displayWidth) + displayWidth + col;
 
       *upperDest = *upperSource;
       *lowerDest = *lowerSource;
@@ -125,7 +119,6 @@ void Adafruit_Protomatter_Chain::correctBuffer()
 // Two calls to this, timed one second apart (or use math with other
 // intervals), can be used to get a rough frames-per-second value for
 // the matrix (since this is difficult to estimate beforehand).
-uint32_t Adafruit_Protomatter_Chain::getFrameCount(void)
-{
+uint32_t Adafruit_Protomatter_Chain::getFrameCount(void) {
   return _PM_getFrameCount(_PM_protoPtr);
 }

--- a/src/Adafruit_Protomatter_Chain.cpp
+++ b/src/Adafruit_Protomatter_Chain.cpp
@@ -1,0 +1,123 @@
+/*!
+ * @file Adafruit_Protomatter_Chain.cpp
+ *
+ * @mainpage Adafruit Protomatter RGB LED matrix library.
+ *
+ * @section intro_sec Introduction
+ *
+ * This is documentation for Adafruit's protomatter library for HUB75-style
+ * RGB LED matrices. It is designed to work with various matrices sold by
+ * Adafruit ("HUB75" is a vague term and other similar matrices are not
+ * guaranteed to work). This file is the Arduino-specific calls; the
+ * underlying C code is more platform-neutral.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing products
+ * from Adafruit!
+ *
+ * @section dependencies Dependencies
+ *
+ * This library depends on
+ * <a href="https://github.com/adafruit/Adafruit-GFX-Library">Adafruit_GFX</a>
+ * being present on your system. Please make sure you have installed the
+ * latest version before using this library.
+ *
+ * @section author Author
+ *
+ * Modified by Mark Komus to support two matricies.
+ * Original code by Phil "Paint Your Dragon" Burgess and Jeff Epler for
+ * Adafruit Industries, with contributions from the open source community.
+ *
+ * @section license License
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+
+// Arduino-specific wrapper for the Protomatter C library (provides
+// constructor and so forth, builds on Adafruit_GFX). There should
+// not be any device-specific #ifdefs here. See notes in core.c and
+// arch/arch.h regarding portability.
+
+#include "Adafruit_Protomatter_Chain.h" // Also includes core.h & Adafruit_GFX.h
+
+extern Protomatter_core *_PM_protoPtr; ///< In core.c (via arch.h)
+
+Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth,
+                                           uint8_t rgbCount, uint8_t *rgbList,
+                                           uint8_t addrCount, uint8_t *addrList,
+                                           uint8_t clockPin, uint8_t latchPin,
+                                           uint8_t oePin, bool doubleBuffer,
+                                           void *timer)
+    : GFXcanvas16(displayWidth, displayHeight) {
+  if (bitDepth > 6)
+    bitDepth = 6; // GFXcanvas16 color limit (565)
+
+  bWidth = bitWidth;
+  uint32_t bytes = displayWidth * displayHeight * 2;
+  if ((correctedBuffer = (uint16_t *)malloc(bytes))) {
+    memset(correctedBuffer, 0, bytes);
+  }
+
+  // Arguments are passed through to the C _PM_init() function which does
+  // some input validation and minor allocation. Return value is ignored
+  // because we can't really do anything about it in a C++ constructor.
+  // The class begin() function checks rgbPins for NULL to determine
+  // whether to proceed or indicate an error.
+  (void)_PM_init(&core, bitWidth, bitDepth, rgbCount, rgbList, addrCount,
+                 addrList, clockPin, latchPin, oePin, doubleBuffer, timer);
+}
+
+Adafruit_Protomatter_Chain::~Adafruit_Protomatter_Chain(void) {
+  _PM_deallocate(&core);
+  _PM_protoPtr = NULL;
+  if (correctedBuffer)
+    free(correctedBuffer);
+}
+
+ProtomatterStatus Adafruit_Protomatter_Chain::begin(void) {
+  _PM_protoPtr = &core;
+  return _PM_begin(&core);
+}
+
+// Transfer data from GFXcanvas16 to the matrix framebuffer's weird
+// internal format. The actual conversion functions referenced below
+// are in core.c, reasoning is explained there.
+void Adafruit_Protomatter_Chain::show(void) {
+  correctBuffer();
+  _PM_convert_565(&core, correctedBuffer, bWidth);
+  _PM_swapbuffer_maybe(&core);
+}
+
+void Adafruit_Protomatter_Chain::correctBuffer() {
+  int16_t displayWidth = width();
+  int16_t displayHeight = height();
+
+  uint16_t *upperdisplay = getBuffer();
+  uint16_t *lowerdisplay = upperdisplay+(displayWidth*displayHeight/2);
+  int size = sizeof(uint16_t);
+
+  // Loop through the entire display
+  // Map the pixels from the display to the correct pixels on the matricies
+  for (int row = 0; row < (displayHeight/2); row++) {
+    for (int col = 0; col < displayWidth; col++) {
+      uint16_t *upperSource = upperdisplay+(row*displayWidth)+col;
+      uint16_t *lowerSource = lowerdisplay+(row*displayWidth)+col;
+
+      uint16_t *upperDest = correctedBuffer + ((displayHeight/2 - row) * displayWidth * 2) - (displayWidth + col + 1);
+      uint16_t *lowerDest = correctedBuffer + (2 * row * displayWidth) + displayWidth + col;
+
+      *upperDest = *upperSource;
+      *lowerDest = *lowerSource;
+    }
+  }
+
+}
+
+// Returns current value of frame counter and resets its value to zero.
+// Two calls to this, timed one second apart (or use math with other
+// intervals), can be used to get a rough frames-per-second value for
+// the matrix (since this is difficult to estimate beforehand).
+uint32_t Adafruit_Protomatter_Chain::getFrameCount(void) {
+  return _PM_getFrameCount(_PM_protoPtr);
+}

--- a/src/Adafruit_Protomatter_Chain.cpp
+++ b/src/Adafruit_Protomatter_Chain.cpp
@@ -44,18 +44,20 @@
 extern Protomatter_core *_PM_protoPtr; ///< In core.c (via arch.h)
 
 Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth,
-                                           uint8_t rgbCount, uint8_t *rgbList,
-                                           uint8_t addrCount, uint8_t *addrList,
-                                           uint8_t clockPin, uint8_t latchPin,
-                                           uint8_t oePin, bool doubleBuffer,
-                                           void *timer)
-    : GFXcanvas16(displayWidth, displayHeight) {
+                                                       uint8_t rgbCount, uint8_t *rgbList,
+                                                       uint8_t addrCount, uint8_t *addrList,
+                                                       uint8_t clockPin, uint8_t latchPin,
+                                                       uint8_t oePin, bool doubleBuffer,
+                                                       void *timer)
+    : GFXcanvas16(displayWidth, displayHeight)
+{
   if (bitDepth > 6)
     bitDepth = 6; // GFXcanvas16 color limit (565)
 
   bWidth = bitWidth;
   uint32_t bytes = displayWidth * displayHeight * 2;
-  if ((correctedBuffer = (uint16_t *)malloc(bytes))) {
+  if ((correctedBuffer = (uint16_t *)malloc(bytes)))
+  {
     memset(correctedBuffer, 0, bytes);
   }
 
@@ -68,14 +70,16 @@ Adafruit_Protomatter_Chain::Adafruit_Protomatter_Chain(uint16_t displayWidth, ui
                  addrList, clockPin, latchPin, oePin, doubleBuffer, timer);
 }
 
-Adafruit_Protomatter_Chain::~Adafruit_Protomatter_Chain(void) {
+Adafruit_Protomatter_Chain::~Adafruit_Protomatter_Chain(void)
+{
   _PM_deallocate(&core);
   _PM_protoPtr = NULL;
   if (correctedBuffer)
     free(correctedBuffer);
 }
 
-ProtomatterStatus Adafruit_Protomatter_Chain::begin(void) {
+ProtomatterStatus Adafruit_Protomatter_Chain::begin(void)
+{
   _PM_protoPtr = &core;
   return _PM_begin(&core);
 }
@@ -83,41 +87,45 @@ ProtomatterStatus Adafruit_Protomatter_Chain::begin(void) {
 // Transfer data from GFXcanvas16 to the matrix framebuffer's weird
 // internal format. The actual conversion functions referenced below
 // are in core.c, reasoning is explained there.
-void Adafruit_Protomatter_Chain::show(void) {
+void Adafruit_Protomatter_Chain::show(void)
+{
   correctBuffer();
   _PM_convert_565(&core, correctedBuffer, bWidth);
   _PM_swapbuffer_maybe(&core);
 }
 
-void Adafruit_Protomatter_Chain::correctBuffer() {
+void Adafruit_Protomatter_Chain::correctBuffer()
+{
   int16_t displayWidth = width();
   int16_t displayHeight = height();
 
   uint16_t *upperdisplay = getBuffer();
-  uint16_t *lowerdisplay = upperdisplay+(displayWidth*displayHeight/2);
+  uint16_t *lowerdisplay = upperdisplay + (displayWidth * displayHeight / 2);
   int size = sizeof(uint16_t);
 
   // Loop through the entire display
   // Map the pixels from the display to the correct pixels on the matricies
-  for (int row = 0; row < (displayHeight/2); row++) {
-    for (int col = 0; col < displayWidth; col++) {
-      uint16_t *upperSource = upperdisplay+(row*displayWidth)+col;
-      uint16_t *lowerSource = lowerdisplay+(row*displayWidth)+col;
+  for (int row = 0; row < (displayHeight / 2); row++)
+  {
+    for (int col = 0; col < displayWidth; col++)
+    {
+      uint16_t *upperSource = upperdisplay + (row * displayWidth) + col;
+      uint16_t *lowerSource = lowerdisplay + (row * displayWidth) + col;
 
-      uint16_t *upperDest = correctedBuffer + ((displayHeight/2 - row) * displayWidth * 2) - (displayWidth + col + 1);
+      uint16_t *upperDest = correctedBuffer + ((displayHeight / 2 - row) * displayWidth * 2) - (displayWidth + col + 1);
       uint16_t *lowerDest = correctedBuffer + (2 * row * displayWidth) + displayWidth + col;
 
       *upperDest = *upperSource;
       *lowerDest = *lowerSource;
     }
   }
-
 }
 
 // Returns current value of frame counter and resets its value to zero.
 // Two calls to this, timed one second apart (or use math with other
 // intervals), can be used to get a rough frames-per-second value for
 // the matrix (since this is difficult to estimate beforehand).
-uint32_t Adafruit_Protomatter_Chain::getFrameCount(void) {
+uint32_t Adafruit_Protomatter_Chain::getFrameCount(void)
+{
   return _PM_getFrameCount(_PM_protoPtr);
 }

--- a/src/Adafruit_Protomatter_Chain.h
+++ b/src/Adafruit_Protomatter_Chain.h
@@ -11,8 +11,7 @@
             library. Subclass of Adafruit_GFX's GFXcanvas16 to allow all
             the drawing operations.
 */
-class Adafruit_Protomatter_Chain : public GFXcanvas16
-{
+class Adafruit_Protomatter_Chain : public GFXcanvas16 {
 public:
   /*!
     @brief  Adafruit_Protomatter constructor.
@@ -61,8 +60,10 @@ public:
                           struct (architecture-dependent), or NULL to
                           use a default timer ID (also arch-dependent).
   */
-  Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth, uint8_t rgbCount,
-                             uint8_t *rgbList, uint8_t addrCount, uint8_t *addrList,
+  Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight,
+                             uint16_t bitWidth, uint8_t bitDepth,
+                             uint8_t rgbCount, uint8_t *rgbList,
+                             uint8_t addrCount, uint8_t *addrList,
                              uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
                              bool doubleBuffer, void *timer = NULL);
 
@@ -119,8 +120,7 @@ public:
     @return Packed 16-bit (uint16_t) color value suitable for GFX drawing
             functions.
   */
-  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue)
-  {
+  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
   }
 

--- a/src/Adafruit_Protomatter_Chain.h
+++ b/src/Adafruit_Protomatter_Chain.h
@@ -1,0 +1,138 @@
+// Arduino-specific header, accompanies Adafruit_Protomatter.cpp.
+// There should not be any device-specific #ifdefs here.
+
+#pragma once
+
+#include "core.h"
+#include <Adafruit_GFX.h>
+
+/*!
+    @brief  Class representing the Arduino-facing side of the Protomatter
+            library. Subclass of Adafruit_GFX's GFXcanvas16 to allow all
+            the drawing operations.
+*/
+class Adafruit_Protomatter_Chain : public GFXcanvas16 {
+public:
+  /*!
+    @brief  Adafruit_Protomatter constructor.
+    @param  displayWidth  Total width of the display, in pixels.
+    @param  displayHeight Total height of the display, in pixels.
+    @param  bitWidth      Total width of RGB matrix chain, in pixels.
+                          Usu. some multiple of 32, but maybe exceptions.
+    @param  bitDepth      Color "depth" in bitplanes, determines range of
+                          shades of red, green and blue. e.g. passing 4
+                          bits = 16 shades ea. R,G,B = 16x16x16 = 4096
+                          colors. Max is 6, since the GFX library works
+                          with "565" RGB colors (6 bits green, 5 red/blue).
+    @param  rgbCount      Number of "sets" of RGB data pins, each set
+                          containing 6 pins (2 ea. R,G,B). Typically 1,
+                          indicating a single matrix (or matrix chain).
+                          In theory (but not yet extensively tested),
+                          multiple sets of pins can be driven in parallel,
+                          up to 5 on some devices (if the hardware design
+                          provides all those bits on one PORT).
+    @param  rgbList       A uint8_t array of pins (Arduino pin numbering),
+                          6X the prior rgbCount value, corresponding to
+                          the 6 output color bits for a matrix (or chain).
+                          Order is upper-half red, green, blue, lower-half
+                          red, green blue (repeat for each add'l chain).
+                          All the RGB pins (plus the clock pin below on
+                          some architectures) MUST be on the same PORT
+                          register. It's recommended (but not required)
+                          that all RGB pins (and clock depending on arch)
+                          be within the same byte of a PORT (but do not
+                          need to be sequential or contiguous within that
+                          byte) for more efficient RAM utilization. For
+                          two concurrent chains, same principle but 16-bit
+                          word instead of byte.
+    @param  addrCount     Number of row address lines required of matrix.
+                          Total pixel height is then 2 x 2^addrCount, e.g.
+                          32-pixel-tall matrices have 4 row address lines.
+    @param  addrList      A uint8_t array of pins (Arduino pin numbering),
+                          one per row address line.
+    @param  clockPin      RGB clock pin (Arduino pin #).
+    @param  latchPin      RGB data latch pin (Arduino pin #).
+    @param  oePin         Output enable pin (Arduino pin #), active low.
+    @param  doubleBuffer  If true, two matrix buffers are allocated,
+                          so changing display contents doesn't introduce
+                          artifacts mid-conversion. Requires ~2X RAM.
+    @param  timer         Pointer to timer peripheral or timer-related
+                          struct (architecture-dependent), or NULL to
+                          use a default timer ID (also arch-dependent).
+  */
+  Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth, uint8_t rgbCount,
+                       uint8_t *rgbList, uint8_t addrCount, uint8_t *addrList,
+                       uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
+                       bool doubleBuffer, void *timer = NULL);
+
+  ~Adafruit_Protomatter_Chain(void);
+
+  /*!
+    @brief  Start a Protomatter matrix display running -- initialize
+            pins, timer and interrupt into existence.
+    @return A ProtomatterStatus status, one of:
+            PROTOMATTER_OK if everything is good.
+            PROTOMATTER_ERR_PINS if data and/or clock pins are split
+            across different PORTs.
+            PROTOMATTER_ERR_MALLOC if insufficient RAM to allocate
+            display memory.
+            PROTOMATTER_ERR_ARG if a bad value was passed to the
+            constructor.
+  */
+  ProtomatterStatus begin(void);
+
+  /*!
+    @brief Process data from GFXcanvas16 to the matrix framebuffer's
+           internal format for display.
+  */
+  void show(void);
+
+  /*!
+    @brief Disable (but do not deallocate) a Protomatter matrix.
+  */
+  void stop(void) { _PM_stop(&core); }
+
+  /*!
+    @brief Resume a previously-stopped matrix.
+  */
+  void resume(void) { _PM_resume(&core); }
+
+  /*!
+    @brief  Returns current value of frame counter and resets its value
+            to zero. Two calls to this, timed one second apart (or use
+            math with other intervals), can be used to get a rough
+            frames-per-second value for the matrix (since this is
+            difficult to estimate beforehand).
+    @return Frame count since previous call to function, as a uint32_t.
+  */
+  uint32_t getFrameCount(void);
+
+  /*!
+    @brief  Converts 24-bit color (8 bits red, green, blue) used in a lot
+            a lot of existing graphics code down to the "565" color format
+            used by Adafruit_GFX. Might get further quantized by matrix if
+            using less than 6-bit depth.
+    @param  red    Red brightness, 0 (min) to 255 (max).
+    @param  green  Green brightness, 0 (min) to 255 (max).
+    @param  blue   Blue brightness, 0 (min) to 255 (max).
+    @return Packed 16-bit (uint16_t) color value suitable for GFX drawing
+            functions.
+  */
+  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
+    return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
+  }
+
+private:
+  /*!
+    @brief  Converts and maps the display buffer into a buffer the matrices can
+            display
+  */
+  void correctBuffer();
+
+  Protomatter_core core;             // Underlying C struct
+  uint16_t *correctedBuffer;
+  uint16_t bWidth;
+  void convert_byte(uint8_t *dest);  // GFXcanvas16-to-matrix
+  void convert_word(uint16_t *dest); // conversion functions
+  void convert_long(uint32_t *dest); // for 8/16/32 bit bufs
+};

--- a/src/Adafruit_Protomatter_Chain.h
+++ b/src/Adafruit_Protomatter_Chain.h
@@ -11,7 +11,8 @@
             library. Subclass of Adafruit_GFX's GFXcanvas16 to allow all
             the drawing operations.
 */
-class Adafruit_Protomatter_Chain : public GFXcanvas16 {
+class Adafruit_Protomatter_Chain : public GFXcanvas16
+{
 public:
   /*!
     @brief  Adafruit_Protomatter constructor.
@@ -61,9 +62,9 @@ public:
                           use a default timer ID (also arch-dependent).
   */
   Adafruit_Protomatter_Chain(uint16_t displayWidth, uint16_t displayHeight, uint16_t bitWidth, uint8_t bitDepth, uint8_t rgbCount,
-                       uint8_t *rgbList, uint8_t addrCount, uint8_t *addrList,
-                       uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
-                       bool doubleBuffer, void *timer = NULL);
+                             uint8_t *rgbList, uint8_t addrCount, uint8_t *addrList,
+                             uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
+                             bool doubleBuffer, void *timer = NULL);
 
   ~Adafruit_Protomatter_Chain(void);
 
@@ -118,7 +119,8 @@ public:
     @return Packed 16-bit (uint16_t) color value suitable for GFX drawing
             functions.
   */
-  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
+  uint16_t color565(uint8_t red, uint8_t green, uint8_t blue)
+  {
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
   }
 
@@ -129,7 +131,7 @@ private:
   */
   void correctBuffer();
 
-  Protomatter_core core;             // Underlying C struct
+  Protomatter_core core; // Underlying C struct
   uint16_t *correctedBuffer;
   uint16_t bWidth;
   void convert_byte(uint8_t *dest);  // GFXcanvas16-to-matrix


### PR DESCRIPTION
Adds in a new class Adafruit_Protomatter_Chain to handle two matrices chained as a square.

It was placed in a separate class with some overlap to Adafruit_Protomatter as that class made display size assumptions based on a rectangular chain. Any changes to Adafruit_Protomatter to use it as a base class would potentially break a lot of code using it already.

I have only tested this with two matrices as that is all I own. I am sure it could be made more generic to handle more in a large configuration but I do not have the equipment to test it. I have also not tested it with two 64x64 matrices but suspect that may work.

I added in a simple example based on two matrices.

Open to any suggestions others may have to improve it.