### PR TITLE
Matrix tiling support

### DIFF
--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -245,6 +245,40 @@ P0.05 5/SCK    P0.13 13/A12   P0.21 21       P0.29          P1.05
 P0.06          P0.14 14/A6    P0.22 22/SCL   P0.30          P1.06
 P0.07          P0.15 15/A8    P0.23 23/SDA   P0.31          P1.07 39/A3 (in)
 
+GRAND CENTRAL M4: (___ = byte boundaries)
+PA00            PB00 D12        PC00 A3        PD00
+PA01            PB01 D13 (LED)  PC01 A4        PD01
+PA02 A0         PB02 D9         PC02 A5        PD02
+PA03 84 (AREF)  PB03 A2         PC03 A6        PD03
+PA04 A13        PB04 A7         PC04 D48       PD04
+PA05 A1         PB05 A8         PC05 D49       PD05
+PA06 A14        PB06 A9         PC06 D46       PD06
+PA07 A15 ______ PB07 A10 ______ PC07 D47 _____ PD07 __________
+PA08            PB08 A11        PC08           PD08 D51 (SCK)
+PA09            PB09 A12        PC09           PD09 D52 (MOSI)
+PA10            PB10            PC10 D45       PD10 D53
+PA11            PB11            PC11 D44       PD11 D50 (MISO)
+PA12 D26        PB12 D18        PC12 D41       PD12 D22
+PA13 D27        PB13 D19        PC13 D40       PD13
+PA14 D28        PB14 D39        PC14 D43       PD14
+PA15 D23 ______ PB15 D38 ______ PC15 D42 _____ PD15 __________
+PA16 D37        PB16 D14        PC16 D25       PD16
+PA17 D36        PB17 D15        PC17 D24       PD17
+PA18 D35        PB18 D8         PC18 D2        PD18
+PA19 D34        PB19 D29        PC19 D3        PD19
+PA20 D33        PB20 D20 (SDA)  PC20 D4        PD20 D6
+PA21 D32        PB21 D21 (SCL)  PC21 D5        PD21 D7
+PA22 D31        PB22 D10        PC22 D16       PD22
+PA23 D30 ______ PB23 D11 ______ PC23 D17 _____ PD23 __________
+PA24            PB24 D1
+PA25            PB25 D0
+PA26            PB26
+PA27            PB27
+PA28            PB28
+PA29            PB29
+PA30            PB30 96 (SWO)
+PA31 __________ PB31 95 (SD CD) ______________________________
+
 RGB MATRIX FEATHERWING NOTES:
 R1  D6    A   A5
 G1  D5    B   A4

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -2,7 +2,9 @@
 "Tiled" Protomatter library example sketch. Demonstrates use of multiple
 RGB LED matrices as a single larger drawing surface. This example is
 written for two 64x32 matrices (tiled into a 64x64 display) but can be
-adapted to others.
+adapted to others. If using MatrixPortal, larger multi-panel tilings like
+this should be powered from a separate 5V DC supply, not the USB port
+(this example works OK because the graphics are very minimal).
 
 PLEASE SEE THE "simple" EXAMPLE FOR AN INTRODUCTORY SKETCH.
 ------------------------------------------------------------------------- */
@@ -75,21 +77,22 @@ supported boards.
 /* ----------------------------------------------------------------------
 Matrix initialization is explained EXTENSIVELY in "simple" example sketch!
 It's very similar here, but we're passing an extra argument to define the
-matrix tiling: -2 means there are two matrices arranged in a "serpentine"
-path (the second matrix is rotated 180 degrees relative to the first, and
-positioned below). A positive 2 would mean a "progressive" path (both
-matrices are oriented the same way), but this requires longer cables.
+matrix tiling along the vertical axis: -2 means there are two matrices
+(or rows of matrices) arranged in a "serpentine" path (the second matrix
+is rotated 180 degrees relative to the first, and positioned below).
+A positive 2 would indicate a "progressive" path (both matrices are
+oriented the same way), but usually requires longer cables.
 ------------------------------------------------------------------------- */
 
 Adafruit_Protomatter matrix(
-  64,          // Width of matrix in pixels
+  64,          // Width of matrix (or matrices, if tiled horizontally)
   6,           // Bit depth, 1-6
   1, rgbPins,  // # of matrix chains, array of 6 RGB pins for each
   4, addrPins, // # of address pins (height is inferred), array of pins
   clockPin, latchPin, oePin, // Other matrix control pins
   false,       // No double-buffering here (see "doublebuffer" example)
-  -2);         // Two matrices tiled vertically in "serpentine" path
-
+  -2);         // Row tiling: two rows in "serpentine" path
+  
 // SETUP - RUNS ONCE AT PROGRAM START --------------------------------------
 
 void setup(void) {
@@ -105,9 +108,9 @@ void setup(void) {
   }
 
   // Since this program has no animation, all the drawing can be done
-  // here in setup() rather than loop():
-
-  // TO DO: add HSV color wheel here
+  // here in setup() rather than loop(). It's just a few basic shapes
+  // that span across the matrices...nothing showy, the goal of this
+  // sketch is just to demonstrate tiling basics.
 
   matrix.drawLine(0, 0, matrix.width() - 1, matrix.height() - 1,
     matrix.color565(255, 0, 0)); // Red line
@@ -116,9 +119,6 @@ void setup(void) {
   int radius = min(matrix.width(), matrix.height()) / 2;
   matrix.drawCircle(matrix.width() / 2, matrix.height() / 2, radius,
     matrix.color565(0, 255, 0)); // Green circle
-
-  // You'll notice the colors look smoother as bit depth increases
-  // (second argument to the matrix constructor call above setup()).
 
   // AFTER DRAWING, A show() CALL IS REQUIRED TO UPDATE THE MATRIX!
 

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -1,0 +1,136 @@
+/* ----------------------------------------------------------------------
+"Tiled" Protomatter library example sketch. Demonstrates use of multiple
+RGB LED matrices as a single larger drawing surface. This example is
+written for two 64x32 matrices (tiled into a 64x64 display) but can be
+adapted to others.
+
+PLEASE SEE THE "simple" EXAMPLE FOR AN INTRODUCTORY SKETCH.
+------------------------------------------------------------------------- */
+
+#include <Adafruit_Protomatter.h>
+
+/* ----------------------------------------------------------------------
+The RGB matrix must be wired to VERY SPECIFIC pins, different for each
+microcontroller board. This first section sets that up for a number of
+supported boards.
+------------------------------------------------------------------------- */
+
+#if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
+  uint8_t rgbPins[]  = {7, 8, 9, 10, 11, 12};
+  uint8_t addrPins[] = {17, 18, 19, 20};
+  uint8_t clockPin   = 14;
+  uint8_t latchPin   = 15;
+  uint8_t oePin      = 16;
+#elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 0;
+  uint8_t oePin      = 1;
+#elif defined(__SAMD51__) // M4 Metro Variants (Express, AirLift)
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 0;
+  uint8_t oePin      = 1;
+#elif defined(_SAMD21_) // Feather M0 variants
+  uint8_t rgbPins[]  = {6, 7, 10, 11, 12, 13};
+  uint8_t addrPins[] = {0, 1, 2, 3};
+  uint8_t clockPin   = SDA;
+  uint8_t latchPin   = 4;
+  uint8_t oePin      = 5;
+#elif defined(NRF52_SERIES) // Special nRF52840 FeatherWing pinout
+  uint8_t rgbPins[]  = {6, A5, A1, A0, A4, 11};
+  uint8_t addrPins[] = {10, 5, 13, 9};
+  uint8_t clockPin   = 12;
+  uint8_t latchPin   = PIN_SERIAL1_RX;
+  uint8_t oePin      = PIN_SERIAL1_TX;
+#elif defined(ESP32)
+  // 'Safe' pins, not overlapping any peripherals:
+  // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
+  // Peripheral-overlapping pins, sorted from 'most expendible':
+  // 16, 17 (RX, TX)
+  // 25, 26 (A0, A1)
+  // 18, 5, 9 (MOSI, SCK, MISO)
+  // 22, 23 (SCL, SDA)
+  uint8_t rgbPins[]  = {4, 12, 13, 14, 15, 21};
+  uint8_t addrPins[] = {16, 17, 25, 26};
+  uint8_t clockPin   = 27; // Must be on same port as rgbPins
+  uint8_t latchPin   = 32;
+  uint8_t oePin      = 33;
+#elif defined(ARDUINO_TEENSY40)
+  uint8_t rgbPins[]  = {15, 16, 17, 20, 21, 22}; // A1-A3, A6-A8, skip SDA,SCL
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#elif defined(ARDUINO_TEENSY41)
+  uint8_t rgbPins[]  = {26, 27, 38, 20, 21, 22}; // A12-14, A6-A8
+  uint8_t addrPins[] = {2, 3, 4, 5};
+  uint8_t clockPin   = 23; // A9
+  uint8_t latchPin   = 6;
+  uint8_t oePin      = 9;
+#endif
+
+/* ----------------------------------------------------------------------
+Matrix initialization is explained EXTENSIVELY in "simple" example sketch!
+It's very similar here, but we're passing an extra argument to define the
+matrix tiling: -2 means there are two matrices arranged in a "serpentine"
+path (the second matrix is rotated 180 degrees relative to the first, and
+positioned below). A positive 2 would mean a "progressive" path (both
+matrices are oriented the same way), but this requires longer cables.
+------------------------------------------------------------------------- */
+
+Adafruit_Protomatter matrix(
+  64,          // Width of matrix in pixels
+  6,           // Bit depth, 1-6
+  1, rgbPins,  // # of matrix chains, array of 6 RGB pins for each
+  4, addrPins, // # of address pins (height is inferred), array of pins
+  clockPin, latchPin, oePin, // Other matrix control pins
+  false,       // No double-buffering here (see "doublebuffer" example)
+  -2);         // Two matrices tiled vertically in "serpentine" path
+
+// SETUP - RUNS ONCE AT PROGRAM START --------------------------------------
+
+void setup(void) {
+  Serial.begin(9600);
+
+  // Initialize matrix...
+  ProtomatterStatus status = matrix.begin();
+  Serial.print("Protomatter begin() status: ");
+  Serial.println((int)status);
+  if(status != PROTOMATTER_OK) {
+    // DO NOT CONTINUE if matrix setup encountered an error.
+    for(;;);
+  }
+
+  // Since this program has no animation, all the drawing can be done
+  // here in setup() rather than loop():
+
+  // TO DO: add HSV color wheel here
+
+  matrix.drawLine(0, 0, matrix.width() - 1, matrix.height() - 1,
+    matrix.color565(255, 0, 0)); // Red line
+  matrix.drawLine(matrix.width() - 1, 0, 0, matrix.height() - 1,
+    matrix.color565(0, 0, 255)); // Blue line
+  int radius = min(matrix.width(), matrix.height()) / 2;
+  matrix.drawCircle(matrix.width() / 2, matrix.height() / 2, radius,
+    matrix.color565(0, 255, 0)); // Green circle
+
+  // You'll notice the colors look smoother as bit depth increases
+  // (second argument to the matrix constructor call above setup()).
+
+  // AFTER DRAWING, A show() CALL IS REQUIRED TO UPDATE THE MATRIX!
+
+  matrix.show(); // Copy data to matrix buffers
+}
+
+// LOOP - RUNS REPEATEDLY AFTER SETUP --------------------------------------
+
+void loop(void) {
+  // Since there's nothing more to be drawn, this loop() function just
+  // prints the approximate refresh rate of the matrix at current settings.
+  Serial.print("Refresh FPS = ~");
+  Serial.println(matrix.getFrameCount());
+  delay(1000);
+}

--- a/src/Adafruit_Protomatter.cpp
+++ b/src/Adafruit_Protomatter.cpp
@@ -48,8 +48,9 @@ Adafruit_Protomatter::Adafruit_Protomatter(uint16_t bitWidth, uint8_t bitDepth,
                                            uint8_t clockPin, uint8_t latchPin,
                                            uint8_t oePin, bool doubleBuffer,
                                            int8_t tile, void *timer)
-    : GFXcanvas16(bitWidth,
-                  (2 << min((int)addrCount, 5)) * min((int)rgbCount, 5)) {
+    : GFXcanvas16(bitWidth, (2 << min((int)addrCount, 5)) *
+                                min((int)rgbCount, 5) *
+                                (tile ? abs(tile) : 1)) {
   if (bitDepth > 6)
     bitDepth = 6; // GFXcanvas16 color limit (565)
 
@@ -87,4 +88,54 @@ void Adafruit_Protomatter::show(void) {
 // the matrix (since this is difficult to estimate beforehand).
 uint32_t Adafruit_Protomatter::getFrameCount(void) {
   return _PM_getFrameCount(_PM_protoPtr);
+}
+
+// This is based on the HSV function in Adafruit_NeoPixel.cpp, but with
+// 16-bit RGB565 output for GFX lib rather than 24-bit. See that code for
+// an explanation of the math, this is stripped of comments for brevity.
+uint16_t Adafruit_Protomatter::colorHSV(uint16_t hue, uint8_t sat,
+                                        uint8_t val) {
+  uint8_t r, g, b;
+
+  hue = (hue * 1530L + 32768) / 65536;
+
+  if (hue < 510) { //         Red to Green-1
+    b = 0;
+    if (hue < 255) { //         Red to Yellow-1
+      r = 255;
+      g = hue;       //           g = 0 to 254
+    } else {         //         Yellow to Green-1
+      r = 510 - hue; //           r = 255 to 1
+      g = 255;
+    }
+  } else if (hue < 1020) { // Green to Blue-1
+    r = 0;
+    if (hue < 765) { //         Green to Cyan-1
+      g = 255;
+      b = hue - 510;  //          b = 0 to 254
+    } else {          //        Cyan to Blue-1
+      g = 1020 - hue; //          g = 255 to 1
+      b = 255;
+    }
+  } else if (hue < 1530) { // Blue to Red-1
+    g = 0;
+    if (hue < 1275) { //        Blue to Magenta-1
+      r = hue - 1020; //          r = 0 to 254
+      b = 255;
+    } else { //                 Magenta to Red-1
+      r = 255;
+      b = 1530 - hue; //          b = 255 to 1
+    }
+  } else { //                 Last 0.5 Red (quicker than % operator)
+    r = 255;
+    g = b = 0;
+  }
+
+  // Apply saturation and value to R,G,B, pack into 16-bit 'RGB565' result:
+  uint32_t v1 = 1 + val;  // 1 to 256; allows >>8 instead of /255
+  uint16_t s1 = 1 + sat;  // 1 to 256; same reason
+  uint8_t s2 = 255 - sat; // 255 to 0
+  return (((((r * s1) >> 8) + s2) * v1) & 0xF800) |
+         ((((((g * s1) >> 8) + s2) * v1) & 0xFC00) >> 5) |
+         (((((b * s1) >> 8) + s2) * v1) >> 11);
 }

--- a/src/Adafruit_Protomatter.cpp
+++ b/src/Adafruit_Protomatter.cpp
@@ -47,7 +47,7 @@ Adafruit_Protomatter::Adafruit_Protomatter(uint16_t bitWidth, uint8_t bitDepth,
                                            uint8_t addrCount, uint8_t *addrList,
                                            uint8_t clockPin, uint8_t latchPin,
                                            uint8_t oePin, bool doubleBuffer,
-                                           void *timer)
+                                           int8_t tile, void *timer)
     : GFXcanvas16(bitWidth,
                   (2 << min((int)addrCount, 5)) * min((int)rgbCount, 5)) {
   if (bitDepth > 6)
@@ -59,7 +59,8 @@ Adafruit_Protomatter::Adafruit_Protomatter(uint16_t bitWidth, uint8_t bitDepth,
   // The class begin() function checks rgbPins for NULL to determine
   // whether to proceed or indicate an error.
   (void)_PM_init(&core, bitWidth, bitDepth, rgbCount, rgbList, addrCount,
-                 addrList, clockPin, latchPin, oePin, doubleBuffer, timer);
+                 addrList, clockPin, latchPin, oePin, doubleBuffer, tile,
+                 timer);
 }
 
 Adafruit_Protomatter::~Adafruit_Protomatter(void) {

--- a/src/Adafruit_Protomatter.h
+++ b/src/Adafruit_Protomatter.h
@@ -54,6 +54,14 @@ public:
     @param  doubleBuffer  If true, two matrix buffers are allocated,
                           so changing display contents doesn't introduce
                           artifacts mid-conversion. Requires ~2X RAM.
+    @param  tile          If multiple matrices are chained and stacked
+                          vertically (rather than or in addition to
+                          horizontally), the number of vertical tiles is
+                          specified here. Positive values indicate a
+                          "progressive" arrangement (always left-to-right),
+                          negative for a "serpentine" arrangement (alternating
+                          180 degree orientation). Horizontal tiles are implied
+                          in the 'bitWidth' argument.
     @param  timer         Pointer to timer peripheral or timer-related
                           struct (architecture-dependent), or NULL to
                           use a default timer ID (also arch-dependent).
@@ -61,7 +69,7 @@ public:
   Adafruit_Protomatter(uint16_t bitWidth, uint8_t bitDepth, uint8_t rgbCount,
                        uint8_t *rgbList, uint8_t addrCount, uint8_t *addrList,
                        uint8_t clockPin, uint8_t latchPin, uint8_t oePin,
-                       bool doubleBuffer, void *timer = NULL);
+                       bool doubleBuffer, int8_t tile = 1, void *timer = NULL);
   ~Adafruit_Protomatter(void);
 
   /*!

--- a/src/Adafruit_Protomatter.h
+++ b/src/Adafruit_Protomatter.h
@@ -127,6 +127,23 @@ public:
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
   }
 
+  /*!
+    @brief   Convert hue, saturation and value into a packed 16-bit RGB color
+             that can be passed to GFX drawing functions.
+    @param   hue  An unsigned 16-bit value, 0 to 65535, representing one full
+                  loop of the color wheel, which allows 16-bit hues to "roll
+                  over" while still doing the expected thing (and allowing
+                  more precision than the wheel() function that was common to
+                  older graphics examples).
+    @param   sat  Saturation, 8-bit value, 0 (min or pure grayscale) to 255
+                  (max or pure hue). Default of 255 if unspecified.
+    @param   val  Value (brightness), 8-bit value, 0 (min / black / off) to
+                  255 (max or full brightness). Default of 255 if unspecified.
+    @return  Packed 16-bit '565' RGB color. Result is linearly but not
+             perceptually correct (no gamma correction).
+  */
+  uint16_t colorHSV(uint16_t hue, uint8_t sat = 255, uint8_t val = 255);
+
 private:
   Protomatter_core core;             // Underlying C struct
   void convert_byte(uint8_t *dest);  // GFXcanvas16-to-matrix

--- a/src/core.c
+++ b/src/core.c
@@ -887,8 +887,7 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
 
   // Size of 1 plane of row pair (across full chain / tile set)
   uint32_t bitplaneSize =
-      _PM_chunkSize *
-      ((core->chainBits + (_PM_chunkSize - 1)) / _PM_chunkSize);
+      _PM_chunkSize * ((core->chainBits + (_PM_chunkSize - 1)) / _PM_chunkSize);
   uint8_t pad = bitplaneSize - core->chainBits; // Plane-start pad
 
   // Skip initial scanline padding if present (HUB75 matrices shift data
@@ -932,13 +931,13 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
 #if defined(_PM_portToggleRegister)
       uint8_t prior = clockMask; // Set clock bit on 1st out
 #endif
-      uint8_t *d2 = dest;
+      uint8_t *d2 = dest; // Incremented per-pixel across all tiles
 
       // Work from bottom tile to top, because data is issued in that order
-      for (int8_t tile = abs(core->tile) - 1; tile >= 0; tile-- ) {
+      for (int8_t tile = abs(core->tile) - 1; tile >= 0; tile--) {
         uint16_t *upperSrc, *lowerSrc; // Canvas scanline pointers
         int16_t srcIdx;
-        int8_t  srcInc;
+        int8_t srcInc;
 
         // Source pointer to tile's upper-left pixel
         uint16_t *srcTileUL = source + tile * width * core->numRowPairs * 2;
@@ -950,9 +949,9 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
           srcInc = -1;
         } else {
           // Progressive tile
-          upperSrc = srcTileUL + width * row; // Top row
+          upperSrc = srcTileUL + width * row;              // Top row
           lowerSrc = upperSrc + width * core->numRowPairs; // Bottom row
-          srcIdx = 0; // Work left to right
+          srcIdx = 0;                                      // Left to right
           srcInc = 1;
         }
 
@@ -979,7 +978,7 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
           *d2++ = result;
 #endif
         } // end x
-      } // end tile
+      }   // end tile
 
       greenBit <<= 1;
       if (plane || (core->numPlanes < 6)) {
@@ -1005,13 +1004,14 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
 #endif
       dest += bitplaneSize; // Advance one scanline in dest buffer
     }                       // end plane
-  } // end row
+  }                         // end row
 }
 
 // Corresponding function for word output -- either 12 RGB bits (2 parallel
 // matrix chains), or 1 chain with RGB bits not in the same byte (but in the
 // same 16-bit word). Some of the comments have been stripped out since it's
 // largely the same operation, but changes are noted.
+// WORD OUTPUT DOES NOT YET SUPPORT ROW TILING.
 void _PM_convert_565_word(Protomatter_core *core, uint16_t *source,
                           uint16_t width) {
   uint16_t *upperSrc = source;                             // Matrix top half
@@ -1125,6 +1125,7 @@ void _PM_convert_565_word(Protomatter_core *core, uint16_t *source,
 // Corresponding function for long output -- either several parallel chains
 // (up to 5), or 1 chain with RGB bits scattered widely about the PORT.
 // Same deal, comments are pared back, see above functions for explanations.
+// LONG OUTPUT DOES NOT YET SUPPORT ROW TILING.
 void _PM_convert_565_long(Protomatter_core *core, uint16_t *source,
                           uint16_t width) {
   uint16_t *upperSrc = source;                             // Matrix top half

--- a/src/core.c
+++ b/src/core.c
@@ -1060,12 +1060,6 @@ void _PM_convert_565_word(Protomatter_core *core, uint16_t *source,
 
   dest += pad; // Pad value is in 'elements,' not bytes, so this is OK
 
-  // After a set of rows+bitplanes are processed, upperSrc and lowerSrc
-  // have advanced halfway down one matrix. This offset is used after
-  // each chain to advance them to the start/middle of the next matrix.
-  uint32_t halfMatrixOffset =
-      core->chainBits * core->numPlanes * core->numRowPairs;
-
   for (uint8_t chain = 0; chain < core->parallel; chain++) {
     for (uint8_t row = 0; row < core->numRowPairs; row++) {
       uint32_t redBit = initialRedBit;
@@ -1188,8 +1182,6 @@ void _PM_convert_565_long(Protomatter_core *core, uint16_t *source,
 #endif
 
   dest += pad; // Pad value is in 'elements,' not bytes, so this is OK
-
-  uint32_t halfMatrixOffset = width * core->numPlanes * core->numRowPairs;
 
   for (uint8_t chain = 0; chain < core->parallel; chain++) {
     for (uint8_t row = 0; row < core->numRowPairs; row++) {


### PR DESCRIPTION
Allows matrices to be stacked vertically.

This is a partially breaking change.
At the C level, definitely breaking: the _PM_init() function REQUIRES an extra argument for tiling, and this is inserted BEFORE the void *timer arg.
At the C++ level, potentially but rarely breaking: the Adafruit_Protomatter constructor likewise accepts an extra argument in a similar position, but with defaults assigned for this and the timer arg, it'll rarely be encountered, UNLESS someone was using the timer arg (super exceedingly rare). I put them in this order because tiling seems more likely than ever using the alt timer functionality.

Tiling + parallel chains doesn’t seem to work. I struggled with this for a bit, but it seems this is not a new problem; parallel chains apparently didn’t work even without chaining, I just hadn’t sufficiently tested that until now. This is super esoteric and we’ve never used it (or attempted to), and the only board that would be able to handle it right now is Grand Central.