### PR TITLE
Circuitpython build fixes

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -32,6 +32,7 @@
 #include "core.h"      // enums and structs
 #include "arch/arch.h" // Do NOT include this in any other source files
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 // Overall matrix refresh rate (frames/second) is a function of matrix width

--- a/src/core.c
+++ b/src/core.c
@@ -941,7 +941,8 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
         int8_t srcInc;
 
         // Source pointer to tile's upper-left pixel
-        const uint16_t *srcTileUL = source + tile * width * core->numRowPairs * 2;
+        const uint16_t *srcTileUL =
+            source + tile * width * core->numRowPairs * 2;
         if ((tile & 1) && (core->tile < 0)) {
           // Special handling for serpentine tiles
           lowerSrc = srcTileUL + width * (core->numRowPairs - 1 - row);

--- a/src/core.c
+++ b/src/core.c
@@ -936,12 +936,12 @@ __attribute__((noinline)) void _PM_convert_565_byte(Protomatter_core *core,
 
       // Work from bottom tile to top, because data is issued in that order
       for (int8_t tile = abs(core->tile) - 1; tile >= 0; tile--) {
-        uint16_t *upperSrc, *lowerSrc; // Canvas scanline pointers
+        const uint16_t *upperSrc, *lowerSrc; // Canvas scanline pointers
         int16_t srcIdx;
         int8_t srcInc;
 
         // Source pointer to tile's upper-left pixel
-        uint16_t *srcTileUL = source + tile * width * core->numRowPairs * 2;
+        const uint16_t *srcTileUL = source + tile * width * core->numRowPairs * 2;
         if ((tile & 1) && (core->tile < 0)) {
           // Special handling for serpentine tiles
           lowerSrc = srcTileUL + width * (core->numRowPairs - 1 - row);


### PR DESCRIPTION
When integrating this code with CircuitPython, I encountered build errors due to diagnostics that are enabled by default in our build system:
```
../../lib/protomatter/src/core.c: In function '_PM_init':
../../lib/protomatter/src/core.c:117:32: error: implicit declaration of function 'abs' [-Werror=implicit-function-declaration]
  117 |   core->chainBits = bitWidth * abs(tile); // Total matrix chain bits
      |                                ^~~
../../lib/protomatter/src/core.c: In function '_PM_convert_565_byte':
../../lib/protomatter/src/core.c:937:7: error: declaration of non-variable 'abs' in 'for' loop initial declaration
  937 |       for (int8_t tile = abs(core->tile) - 1; tile >= 0; tile--) {
      |       ^~~
../../lib/protomatter/src/core.c:943:31: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  943 |         uint16_t *srcTileUL = source + tile * width * core->numRowPairs * 2;
      |                               ^~~~~~
```
.. these changes fix the build errors and are needed before we can integrate tiling in CircuitPython.