### PR TITLE
RP2040 support (sorta)

### DIFF
--- a/examples/animated_gif/animated_gif.ino
+++ b/examples/animated_gif/animated_gif.ino
@@ -89,7 +89,7 @@ int16_t xPos = 0, yPos = 0; // Top-left pixel coord of GIF in matrix space
 // FILE ACCESS FUNCTIONS REQUIRED BY ANIMATED GIF LIB ----------------------
 
 // Pass in ABSOLUTE PATH of GIF file to open
-void *GIFOpenFile(const char *filename, int32_t *pSize) {
+void *GIFOpenFile(char *filename, int32_t *pSize) {
   GIFfile = filesys.open(filename);
   if (GIFfile) {
     *pSize = GIFfile.size();

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -167,6 +167,7 @@ _PM_free:                    Corresponding deallocator for _PM_allocate().
 
 #include "esp32.h"
 #include "nrf52.h"
+#include "rp2040.h"
 #include "samd-common.h"
 #include "samd21.h"
 #include "samd51.h"

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -60,7 +60,7 @@ void *_PM_protoPtr = NULL;
 // 'pin' here is GPXX # -- that might change in Arduino implementation
 #define _PM_portBitMask(pin) (1UL << pin)
 // Same for these -- using GPXX #, but Arduino might assign different order
-#define _PM_pinOutput(pin) gpio_set_dir(pin, GPIO_OUT)
+#define _PM_pinOutput(pin) { gpio_init(pin); gpio_set_dir(pin, GPIO_OUT); }
 #define _PM_pinLow(pin) gpio_clr_mask(1UL << pin)
 #define _PM_pinHigh(pin) gpio_set_mask(1UL << pin)
 

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -15,11 +15,12 @@
  *
  * RP2040 NOTES: This initial implementation does NOT use PIO. That's normal
  * for Protomatter, which was written for simple GPIO + timer interrupt for
- * broadest portability. While not optimal, it's not necessarily pessimal
- * either...no worse than any other platform where we're not taking
- * advantage of device-specific DMA or peripherals. Would require changes
- * to the 'blast' functions or possibly the whole _PM_row_handler() (both
- * currently in core.c).
+ * broadest portability (using PWM as a timer in this case). While not
+ * entirely optimal, it's not pessimal either...no worse than any other
+ * platform where we're not taking advantage of device-specific DMA or
+ * peripherals. Would require changes to the 'blast' functions or possibly
+ * the whole _PM_row_handler() (both currently in core.c). CPU load is just
+ * a few percent for a 64x32 matrix @ 6-bit depth.
  *
  */
 
@@ -28,10 +29,9 @@
 // TO DO: PUT A *PROPER* RP2040 CHECK HERE
 #if defined(PICO_BOARD)
 
-#include "pico/stdlib.h" // For sio_hw, etc.
-#include "hardware/timer.h"
+#include "../../hardware_pwm/include/hardware/pwm.h"
 #include "hardware/irq.h"
-#include "time.h"
+#include "pico/stdlib.h" // For sio_hw, etc.
 
 // RP2040 only allows full 32-bit aligned writes to GPIO.
 #define _PM_STRICT_32BIT_IO ///< Change core.c behavior for long accesses only
@@ -50,10 +50,10 @@
 #define _PM_wordOffset(pin) (1 - ((pin & 31) / 16))
 #endif
 
-// Arduino implementation is tied to a specific timer & freq:
-#define _PM_ALARM_NUM 1
-#define _PM_IRQ_HANDLER TIMER_IRQ_1
-#define _PM_timerFreq 1000000
+// Arduino implementation is tied to a specific PWM slice & frequency
+#define _PM_PWM_SLICE 0
+#define _PM_PWM_DIV 3 // ~41.6 MHz, similar to SAMD
+#define _PM_timerFreq (125000000 / _PM_PWM_DIV)
 #define _PM_TIMER_DEFAULT NULL
 
 // Because it's tied to a specific timer right now, there can be only
@@ -68,47 +68,53 @@ void *_PM_protoPtr = NULL;
 // 'pin' here is GPXX # -- that might change in Arduino implementation
 #define _PM_portBitMask(pin) (1UL << pin)
 // Same for these -- using GPXX #, but Arduino might assign different order
-#define _PM_pinOutput(pin) { gpio_init(pin); gpio_set_dir(pin, GPIO_OUT); }
+#define _PM_pinOutput(pin)                                                     \
+  {                                                                            \
+    gpio_init(pin);                                                            \
+    gpio_set_dir(pin, GPIO_OUT);                                               \
+  }
 #define _PM_pinLow(pin) gpio_clr_mask(1UL << pin)
 #define _PM_pinHigh(pin) gpio_set_mask(1UL << pin)
 
 #define _PM_delayMicroseconds(n) sleep_us(n)
 
-static void _PM_timerISR(void) {
-  hw_clear_bits(&timer_hw->intr, 1u << _PM_ALARM_NUM); // Clear alarm flag
+static void _PM_PWM_ISR(void) {
+  pwm_clear_irq(_PM_PWM_SLICE);  // Reset PWM wrap interrupt
   _PM_row_handler(_PM_protoPtr); // In core.c
 }
 
 // Initialize, but do not start, timer.
 void _PM_timerInit(void *tptr) {
-  timer_hw->alarm[_PM_ALARM_NUM] = timer_hw->timerawl; // Clear any timer
-  hw_set_bits(&timer_hw->inte, 1u << _PM_ALARM_NUM);
-  irq_set_exclusive_handler(_PM_IRQ_HANDLER, _PM_timerISR); // Set IRQ handler
-}
 
-// Unlike timers on other devices, on RP2040 you don't reset a counter to
-// zero at the start of a cycle. To emulate that behavior (for determining
-// elapsed times), the timer start time must be saved somewhere...
-static uint32_t _PM_timerSave;
+  // Enable PWM wrap interrupt
+  pwm_clear_irq(_PM_PWM_SLICE);
+  pwm_set_irq_enabled(_PM_PWM_SLICE, true);
+  irq_set_exclusive_handler(PWM_IRQ_WRAP, _PM_PWM_ISR);
+  irq_set_enabled(PWM_IRQ_WRAP, true);
+
+  // Config but do not start PWM
+  pwm_config config = pwm_get_default_config();
+  pwm_config_set_clkdiv_int(&config, _PM_PWM_DIV);
+  pwm_init(_PM_PWM_SLICE, &config, true);
+}
 
 // Set timer period and enable timer.
 inline void _PM_timerStart(void *tptr, uint32_t period) {
-  irq_set_enabled(_PM_IRQ_HANDLER, true); // Enable alarm IRQ
-  _PM_timerSave = timer_hw->timerawl; // Time at start
-  uint32_t target = _PM_timerSave + period; // Time at end
-  timer_hw->alarm[_PM_ALARM_NUM] = target;
+  pwm_set_counter(_PM_PWM_SLICE, 0);
+  pwm_set_wrap(_PM_PWM_SLICE, period);
+  pwm_set_enabled(_PM_PWM_SLICE, true);
 }
 
 // Return current count value (timer enabled or not).
 // Timer must be previously initialized.
 inline uint32_t _PM_timerGetCount(void *tptr) {
-  return timer_hw->timerawl - _PM_timerSave;
+  return pwm_get_counter(_PM_PWM_SLICE);
 }
 
 // Disable timer and return current count value.
 // Timer must be previously initialized.
 uint32_t _PM_timerStop(void *tptr) {
-  irq_set_enabled(_PM_IRQ_HANDLER, false); // Disable alarm IRQ
+  pwm_set_enabled(_PM_PWM_SLICE, false);
   return _PM_timerGetCount(tptr);
 }
 
@@ -121,6 +127,6 @@ uint32_t _PM_timerStop(void *tptr) {
 
 #define _PM_chunkSize 8
 #define _PM_clockHoldLow asm("nop; nop;");
-#define _PM_minMinPeriod 8
+#define _PM_minMinPeriod 100
 
 #endif // END PICO_BOARD

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -15,12 +15,12 @@
  *
  * RP2040 NOTES: This initial implementation does NOT use PIO. That's normal
  * for Protomatter, which was written for simple GPIO + timer interrupt for
- * broadest portability (using PWM as a timer in this case). While not
- * entirely optimal, it's not pessimal either...no worse than any other
- * platform where we're not taking advantage of device-specific DMA or
- * peripherals. Would require changes to the 'blast' functions or possibly
- * the whole _PM_row_handler() (both currently in core.c). CPU load is just
- * a few percent for a 64x32 matrix @ 6-bit depth.
+ * broadest portability. While not entirely optimal, it's not pessimal
+ * either...no worse than any other platform where we're not taking
+ * advantage of device-specific DMA or peripherals. Would require changes to
+ * the 'blast' functions or possibly the whole _PM_row_handler() (both
+ * currently in core.c). CPU load is just a few percent for a 64x32
+ * matrix @ 6-bit depth, so I'm not losing sleep over this.
  *
  */
 
@@ -31,6 +31,7 @@
 
 #include "../../hardware_pwm/include/hardware/pwm.h"
 #include "hardware/irq.h"
+#include "hardware/timer.h"
 #include "pico/stdlib.h" // For sio_hw, etc.
 
 // RP2040 only allows full 32-bit aligned writes to GPIO.
@@ -38,6 +39,11 @@
 
 // TEMPORARY: FORCING ARDUINO COMPILATION FOR INITIAL C TESTING
 #define ARDUINO
+
+// Enable this to use PWM for bitplane timing, else a timer alarm is used.
+// PWM has finer resolution, but alarm is adequate -- this is more about
+// which peripheral we'd rather use, as both are finite resources.
+#define _PM_CLOCK_PWM
 
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 
@@ -50,11 +56,28 @@
 #define _PM_wordOffset(pin) (1 - ((pin & 31) / 16))
 #endif
 
+#if defined(_PM_CLOCK_PWM)
+
 // Arduino implementation is tied to a specific PWM slice & frequency
 #define _PM_PWM_SLICE 0
 #define _PM_PWM_DIV 3 // ~41.6 MHz, similar to SAMD
 #define _PM_timerFreq (125000000 / _PM_PWM_DIV)
 #define _PM_TIMER_DEFAULT NULL
+
+#else // Use alarm for timing
+
+// Arduino implementation is tied to a specific timer alarm & frequency
+#define _PM_ALARM_NUM 1
+#define _PM_IRQ_HANDLER TIMER_IRQ_1
+#define _PM_timerFreq 1000000
+#define _PM_TIMER_DEFAULT NULL
+
+// Unlike timers on other devices, on RP2040 you don't reset a counter to
+// zero at the start of a cycle. To emulate that behavior (for determining
+// elapsed times), the timer start time must be saved somewhere...
+static volatile uint32_t _PM_timerSave;
+
+#endif
 
 // Because it's tied to a specific timer right now, there can be only
 // one instance of the Protomatter_core struct. The Arduino library
@@ -78,14 +101,21 @@ void *_PM_protoPtr = NULL;
 
 #define _PM_delayMicroseconds(n) sleep_us(n)
 
+#if defined(_PM_CLOCK_PWM) // Use PWM for timing
 static void _PM_PWM_ISR(void) {
   pwm_clear_irq(_PM_PWM_SLICE);  // Reset PWM wrap interrupt
   _PM_row_handler(_PM_protoPtr); // In core.c
 }
+#else // Use timer alarm for timing
+static void _PM_timerISR(void) {
+  hw_clear_bits(&timer_hw->intr, 1u << _PM_ALARM_NUM); // Clear alarm flag
+  _PM_row_handler(_PM_protoPtr);                       // In core.c
+}
+#endif
 
 // Initialize, but do not start, timer.
 void _PM_timerInit(void *tptr) {
-
+#if defined(_PM_CLOCK_PWM)
   // Enable PWM wrap interrupt
   pwm_clear_irq(_PM_PWM_SLICE);
   pwm_set_irq_enabled(_PM_PWM_SLICE, true);
@@ -96,25 +126,44 @@ void _PM_timerInit(void *tptr) {
   pwm_config config = pwm_get_default_config();
   pwm_config_set_clkdiv_int(&config, _PM_PWM_DIV);
   pwm_init(_PM_PWM_SLICE, &config, true);
+#else
+  timer_hw->alarm[_PM_ALARM_NUM] = timer_hw->timerawl; // Clear any timer
+  hw_set_bits(&timer_hw->inte, 1u << _PM_ALARM_NUM);
+  irq_set_exclusive_handler(_PM_IRQ_HANDLER, _PM_timerISR); // Set IRQ handler
+#endif
 }
 
 // Set timer period and enable timer.
 inline void _PM_timerStart(void *tptr, uint32_t period) {
+#if defined(_PM_CLOCK_PWM)
   pwm_set_counter(_PM_PWM_SLICE, 0);
   pwm_set_wrap(_PM_PWM_SLICE, period);
   pwm_set_enabled(_PM_PWM_SLICE, true);
+#else
+  irq_set_enabled(_PM_IRQ_HANDLER, true);                   // Enable alarm IRQ
+  _PM_timerSave = timer_hw->timerawl;                       // Time at start
+  timer_hw->alarm[_PM_ALARM_NUM] = _PM_timerSave + period;  // Time at end
+#endif
 }
 
 // Return current count value (timer enabled or not).
 // Timer must be previously initialized.
 inline uint32_t _PM_timerGetCount(void *tptr) {
+#if defined(_PM_CLOCK_PWM)
   return pwm_get_counter(_PM_PWM_SLICE);
+#else
+  return timer_hw->timerawl - _PM_timerSave;
+#endif
 }
 
 // Disable timer and return current count value.
 // Timer must be previously initialized.
 uint32_t _PM_timerStop(void *tptr) {
+#if defined(_PM_CLOCK_PWM)
   pwm_set_enabled(_PM_PWM_SLICE, false);
+#else
+  irq_set_enabled(_PM_IRQ_HANDLER, false); // Disable alarm IRQ
+#endif
   return _PM_timerGetCount(tptr);
 }
 
@@ -127,6 +176,10 @@ uint32_t _PM_timerStop(void *tptr) {
 
 #define _PM_chunkSize 8
 #define _PM_clockHoldLow asm("nop; nop;");
+#if defined(_PM_CLOCK_PWM)
 #define _PM_minMinPeriod 100
+#else
+#define _PM_minMinPeriod 8
+#endif
 
 #endif // END PICO_BOARD

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -114,7 +114,7 @@ uint32_t _PM_timerStop(void *tptr) {
 
 #endif // END PICO_BOARD
 
-#define _PM_chunkSize 1 ///< DON'T unroll loop
+#define _PM_chunkSize 8
 
 
 

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -1,0 +1,133 @@
+/*!
+ * @file rp2040.h
+ *
+ * Part of Adafruit's Protomatter library for HUB75-style RGB LED matrices.
+ * This file contains RP2040 (Raspberry Pi Pico, etc.) SPECIFIC CODE.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Written by Phil "Paint Your Dragon" Burgess and Jeff Epler for
+ * Adafruit Industries, with contributions from the open source community.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+
+#pragma once
+
+// TO DO: PUT A *PROPER* RP2040 CHECK HERE
+#if defined(PICO_BOARD)
+
+#include "pico/stdlib.h" // For sio_hw, etc.
+#include "hardware/timer.h"
+#include "hardware/irq.h"
+#include "time.h"
+
+// RP2040 only allows full 32-bit aligned writes to GPIO.
+#define _PM_STRICT_32BIT_IO ///< Change core.c behavior for long accesses only
+
+// TEMPORARY: FORCING ARDUINO COMPILATION FOR INITIAL C TESTING
+#define ARDUINO
+
+#if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
+
+// 'pin' here is GPXX # -- that might change in Arduino implementation
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define _PM_byteOffset(pin) ((pin & 31) / 8)
+#define _PM_wordOffset(pin) ((pin & 31) / 16)
+#else
+#define _PM_byteOffset(pin) (3 - ((pin & 31) / 8))
+#define _PM_wordOffset(pin) (1 - ((pin & 31) / 16))
+#endif
+
+// Arduino implementation is tied to a specific timer & freq:
+#define _PM_ALARM_NUM 0
+#define _PM_IRQ_HANDLER TIMER_IRQ_0
+#define _PM_timerFreq 1000000
+#define _PM_TIMER_DEFAULT NULL
+
+// Because it's tied to a specific timer right now, there can be only
+// one instance of the Protomatter_core struct. The Arduino library
+// sets up this pointer when calling begin().
+void *_PM_protoPtr = NULL;
+
+#define _PM_portOutRegister(pin) ((void *)&sio_hw->gpio_out)
+#define _PM_portSetRegister(pin) ((volatile uint32_t *)&sio_hw->gpio_set)
+#define _PM_portClearRegister(pin) ((volatile uint32_t *)&sio_hw->gpio_clr)
+#define _PM_portToggleRegister(pin) ((volatile uint32_t *)&sio_hw->gpio_togl)
+// 'pin' here is GPXX # -- that might change in Arduino implementation
+#define _PM_portBitMask(pin) (1UL << pin)
+// Same for these -- using GPXX #, but Arduino might assign different order
+#define _PM_pinOutput(pin) gpio_set_dir(pin, GPIO_OUT)
+#define _PM_pinLow(pin) gpio_clr_mask(1UL << pin)
+#define _PM_pinHigh(pin) gpio_set_mask(1UL << pin)
+
+#define _PM_delayMicroseconds(n) sleep_us(n)
+
+static void _PM_timerISR(void) {
+  hw_clear_bits(&timer_hw->intr, 1u << _PM_ALARM_NUM); // Clear alarm flag
+  _PM_row_handler(_PM_protoPtr); // In core.c
+}
+
+// Initialize, but do not start, timer.
+void _PM_timerInit(void *tptr) {
+  timer_hw->alarm[_PM_ALARM_NUM] = timer_hw->timerawl; // Clear any timer
+  hw_set_bits(&timer_hw->inte, 1u << _PM_ALARM_NUM);
+  irq_set_exclusive_handler(_PM_IRQ_HANDLER, _PM_timerISR); // Set IRQ handler
+}
+
+// Unlike timers on other devices, on RP2040 you don't reset a counter to
+// zero at the start of a cycle. To emulate that behavior (for determining
+// elapsed times), the timer start time must be saved somewhere...
+static uint64_t _PM_timerSave;
+
+// Set timer period and enable timer.
+inline void _PM_timerStart(void *tptr, uint32_t period) {
+  _PM_timerSave = timer_hw->timerawl; // Time at start
+  uint64_t target = _PM_timerSave + period; // Time at end
+  timer_hw->alarm[_PM_ALARM_NUM] = (uint32_t)target;
+
+  irq_set_enabled(_PM_IRQ_HANDLER, true); // Enable alarm IRQ
+}
+
+// Return current count value (timer enabled or not).
+// Timer must be previously initialized.
+inline uint32_t _PM_timerGetCount(void *tptr) {
+  return (uint32_t)(timer_hw->timerawl - _PM_timerSave);
+}
+
+// Disable timer and return current count value.
+// Timer must be previously initialized.
+uint32_t _PM_timerStop(void *tptr) {
+  irq_set_enabled(_PM_IRQ_HANDLER, false); // Disable alarm IRQ
+  return _PM_timerGetCount(tptr);
+}
+
+#elif defined(CIRCUITPY) // COMPILING FOR CIRCUITPYTHON --------------------
+
+// RP2040 CircuitPython magic goes here.
+// Put anything common to Arduino & CircuitPython above the platform ifdefs.
+
+#endif // END CIRCUITPYTHON ------------------------------------------------
+
+#endif // END PICO_BOARD
+
+#define _PM_chunkSize 1 ///< DON'T unroll loop
+
+
+
+
+
+
+#if 0
+
+#define _PM_clockHoldHigh                                                      \
+  asm("nop; nop; nop; nop; nop; nop; nop;");                                   \
+  asm("nop; nop; nop; nop; nop; nop; nop;");
+#define _PM_clockHoldLow                                                       \
+  asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;");                    \
+  asm("nop; nop; nop; nop; nop; nop; nop; nop; nop; nop;");
+
+#endif // 0

--- a/src/arch/stm32.h
+++ b/src/arch/stm32.h
@@ -123,6 +123,11 @@ inline void _PM_timerStart(void *tptr, uint32_t period) {
   HAL_NVIC_EnableIRQ(stm_peripherals_timer_get_irqnum(tim));
 }
 
+inline uint32_t _PM_timerGetCount(void *tptr) {
+  TIM_TypeDef *tim = tptr;
+  return tim->CNT;
+}
+
 uint32_t _PM_timerStop(void *tptr) {
   TIM_TypeDef *tim = tptr;
   HAL_NVIC_DisableIRQ(stm_peripherals_timer_get_irqnum(tim));

--- a/src/core.c
+++ b/src/core.c
@@ -572,6 +572,11 @@ IRAM_ATTR void _PM_row_handler(Protomatter_core *core) {
   // issue (not necessarily display) the data for one bitplane, and the
   // minimum value that should be allowed for bitplane 0. It's filtered
   // slightly to avoid jitter.
+  // Please see notes-to-self at end of file. This is garbage. It's not
+  // harmful just sitting here, but it doesn't do what was originally
+  // intended and should either be removed (along with some associated
+  // variables) or be revised, which would require work in all of the
+  // arch-specific files.
   if (prevPlane == 0) {
     // Determine number of timer cycles needed to issue the data
     uint32_t elapsed = _PM_timerGetCount(core->timer);
@@ -1279,18 +1284,59 @@ void _PM_convert_565(Protomatter_core *core, uint16_t *source, uint16_t width) {
 
 #endif // END ARDUINO || CIRCUITPY
 
-// Note to future self: I've gone back and forth between implementing all
-// this either as it currently is (with byte, word and long cases for various
-// steps), or using a uint32_t[64] table for expanding RGB bit combos to PORT
-// bit combos. The latter would certainly simplify the code a ton, and the
-// additional table lookup step wouldn't significantly impact performance,
-// especially going forward with faster processors (the SAMD51 code already
-// requires a few NOPs in the innermost loop to avoid outpacing the matrix).
-// BUT, the reason this is NOT currently done is that it only allows for a
-// single matrix chain (doing parallel chains would require either an
-// impractically large lookup table, or adding together multiple tables'
-// worth of bitmasks, which would slow things down in the vital inner loop).
-// Although parallel matrix chains aren't yet 100% implemented in this code
-// right now, I wanted to leave that possibility for the future, as a way to
-// handle larger matrix combos, because long chains will slow down the
-// refresh rate.
+/* NOTES TO FUTURE SELF ----------------------------------------------------
+
+ON BYTES, WORDS and LONGS:
+I've gone back and forth between implementing all this either as it
+currently is (with byte, word and long cases for various steps), or using
+a uint32_t[64] table for expanding RGB bit combos to PORT bit combos.
+The latter would certainly simplify the code a ton, and the additional
+table lookup step wouldn't significantly impact performance, especially
+going forward with faster processors (several devices already require a
+few NOPs in the innermost loop to avoid outpacing the matrix).
+BUT, the reason this is NOT currently done is that it only allows for a
+single matrix chain (doing parallel chains would require either an
+impractically large lookup table, or adding together multiple tables'
+worth of bitmasks, which would slow things down in the vital inner loop).
+Although parallel matrix chains aren't yet 100% implemented in this code
+right now, I wanted to leave that possibility for the future, as a way to
+handle larger matrix combos, because long chains will slow down the
+refresh rate.
+
+ON BITPLANE TIMING:
+The library uses bit-angle modulation (vs PWM) for pixel brightness --
+each successive bitplane is shown for 2X as long as the previous plane.
+The least-bit (bitplane 0) interval is calculated in _PM_init() using
+matrix size, bit depth and _PM_MAX_REFRESH_HZ.
+There are vestiges of code in here for something that doesn't work, and
+hasn't reared its head as a problem, but might be a desirable feature in
+the future, though this would require changes in most if not all arch-
+specific files. What the code was originally planning to do was, if it
+takes longer than the least-bit interval to issue the data for one
+bitplane (which would result in the least-bit being disproportionally
+bright, throwing off the grayscale appearance), it would adaptively
+adjust the least-bit time upward (reducing the refresh rate, but
+maintaining the powers-of-two bitplane timings)...but, if that's a
+temporary situation (e.g. due to other interrupts or something), would
+also adaptively adjust the time back downward when possible (but never
+exceeding _PM_MAX_REFRESH_HZ, because that would just waste CPU time from
+other tasks with little to no benefit to the display). That was the idea
+but IT NEVER ACTUALLY GOT IMPLEMENTED THIS WAY due to various reasons.
+To make this work requires changes to the timers and interrupts, unique
+to each architecture. What it should be doing is configuring the timers
+to roll over at MAX (e.g. 65535 for a 16-bit timer), and set the bitplane
+timing with a compare-match interrupt, NOT a rollover interrupt. This
+allows the counter to keep running post-interrupt, so the data-issuing
+time (if greater than the least-bit time) can be correctly gauged, and
+timing adjusted if necessary (as it is, the timer stops or rolls over at
+the least-bit time, so the value read will never exceed that value).
+Additionally, since we're getting into tiling and longer matrix chains
+now, most or all architectures should use slower timer/counter clocks
+so they don't risk overflowing on higher bitplanes (changing the clock
+dividers per-plane is NOT used because the implementation varies too
+much between architectures -- instead a fixed divider is used, and the
+counter limit is doubled each bitplane). The timer/counter clock does
+NOT affect the data-issuing time, it's strictly for gauging the powers-
+of-two timing intervals, and therefore doesn't really need to be as
+high-res as currently implemented...even a 1 MHz clock can suffice.
+*/

--- a/src/core.c
+++ b/src/core.c
@@ -628,7 +628,7 @@ IRAM_ATTR void _PM_row_handler(Protomatter_core *core) {
   _PM_clockHoldLow;                                                            \
   *set = clock; /* Set clock high */                                           \
   _PM_clockHoldHigh;                                                           \
-  *clear = rgbclock; /* Clear RGB data + clock */                              \
+  *clear_full = rgbclock; /* Clear RGB data + clock */                         \
   ///< Bitbang one set of RGB data bits to matrix
 #endif
 
@@ -714,7 +714,7 @@ IRAM_ATTR static void blast_byte(Protomatter_core *core, uint8_t *data) {
   volatile _PM_PORT_TYPE *toggle = (volatile _PM_PORT_TYPE *)core->toggleReg;
 #else
   volatile _PM_PORT_TYPE *set = (volatile _PM_PORT_TYPE *)core->setReg;
-  volatile _PM_PORT_TYPE *clear = (volatile _PM_PORT_TYPE *)core->clearReg;
+  volatile _PM_PORT_TYPE *clear_full = (volatile _PM_PORT_TYPE *)core->clearReg;
   _PM_PORT_TYPE rgbclock = core->rgbAndClockMask; // RGB + clock bit
 #endif
   _PM_PORT_TYPE clock = core->clockMask; // Clock bit
@@ -768,7 +768,7 @@ IRAM_ATTR static void blast_word(Protomatter_core *core, uint16_t *data) {
   volatile _PM_PORT_TYPE *toggle = (volatile _PM_PORT_TYPE *)core->toggleReg;
 #else
   volatile _PM_PORT_TYPE *set = (volatile _PM_PORT_TYPE *)core->setReg;
-  volatile _PM_PORT_TYPE *clear = (volatile _PM_PORT_TYPE *)core->clearReg;
+  volatile _PM_PORT_TYPE *clear_full = (volatile _PM_PORT_TYPE *)core->clearReg;
   _PM_PORT_TYPE rgbclock = core->rgbAndClockMask; // RGB + clock bit
 #endif
   _PM_PORT_TYPE clock = core->clockMask; // Clock bit

--- a/src/core.c
+++ b/src/core.c
@@ -579,7 +579,7 @@ IRAM_ATTR void _PM_row_handler(Protomatter_core *core) {
   if (prevPlane == 0) {
     // Determine number of timer cycles needed to issue the data
     uint32_t elapsed = _PM_timerGetCount(core->timer);
-    core->bitZeroPeriod = ((core->bitZeroPeriod * 7) + elapsed) / 8;
+    core->bitZeroPeriod = ((core->bitZeroPeriod * 7) + elapsed + 4) / 8;
     if (core->bitZeroPeriod < core->minPeriod) {
       core->bitZeroPeriod = core->minPeriod;
     }

--- a/src/core.c
+++ b/src/core.c
@@ -1339,4 +1339,9 @@ counter limit is doubled each bitplane). The timer/counter clock does
 NOT affect the data-issuing time, it's strictly for gauging the powers-
 of-two timing intervals, and therefore doesn't really need to be as
 high-res as currently implemented...even a 1 MHz clock can suffice.
+UPDATE: actually that's not entirely true, the code can work with the
+timers as they are, no rewrite needed...trick is to check the data-
+issuing time on the last (longest) bitplane, since the timer will
+certainly still be running, and use that for fine-tuning the least-bit
+duration.
 */

--- a/src/core.c
+++ b/src/core.c
@@ -322,8 +322,7 @@ ProtomatterStatus _PM_begin(Protomatter_core *core) {
   // Make a wild guess for the initial bit-zero interval. It's okay
   // that this is off, code adapts to actual timer results pretty quick.
 
-  //core->bitZeroPeriod = core->chainBits * 5; // Initial guesstimate
-  core->bitZeroPeriod = _PM_minMinPeriod * 2; // Initial guesstimate
+  core->bitZeroPeriod = core->chainBits * 5; // Initial guesstimate
 
   core->activeBuffer = 0;
 

--- a/src/core.c
+++ b/src/core.c
@@ -322,7 +322,8 @@ ProtomatterStatus _PM_begin(Protomatter_core *core) {
   // Make a wild guess for the initial bit-zero interval. It's okay
   // that this is off, code adapts to actual timer results pretty quick.
 
-  core->bitZeroPeriod = core->chainBits * 5; // Initial guesstimate
+  //core->bitZeroPeriod = core->chainBits * 5; // Initial guesstimate
+  core->bitZeroPeriod = _PM_minMinPeriod * 2; // Initial guesstimate
 
   core->activeBuffer = 0;
 


### PR DESCRIPTION
This is a work-in-progress and requires further changes from @jepler’s branch to get it CircuitPython-ready.

Since there’s no Arduino core support for RP2040 yet, the “Arduino” section of that header is not fully formed and will need minor tweaks when the time comes. This was tested with the RP2040 C toolchain and runs in a limited context…not really knowing what the canonical Arduino #ifdef checks will be yet. But as is, shouldn’t prevent things from compiling on other architectures.