### PR TITLE
rp2040: Need to enable/disable the PWM_IRQ_WRAP at these times

### DIFF
--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -179,6 +179,7 @@ inline void _PM_timerStart(void *tptr, uint32_t period) {
   pwm_set_counter(_PM_PWM_SLICE, 0);
   pwm_set_wrap(_PM_PWM_SLICE, period);
   pwm_set_enabled(_PM_PWM_SLICE, true);
+  irq_set_enabled(PWM_IRQ_WRAP, true);
 #else
   irq_set_enabled(_PM_IRQ_HANDLER, true);                   // Enable alarm IRQ
   _PM_timerSave = timer_hw->timerawl;                       // Time at start
@@ -201,6 +202,7 @@ inline uint32_t _PM_timerGetCount(void *tptr) {
 uint32_t _PM_timerStop(void *tptr) {
 #if _PM_CLOCK_PWM
   pwm_set_enabled(_PM_PWM_SLICE, false);
+  irq_set_enabled(PWM_IRQ_WRAP, false);
 #else
   irq_set_enabled(_PM_IRQ_HANDLER, false); // Disable alarm IRQ
 #endif


### PR DESCRIPTION
While debugging https://github.com/adafruit/circuitpython/pull/4186 I found that the IRQ could be entered at unexpected times, such as (during reinitialization of a display),
```
#0  0x10069088 in _PM_row_handler (core=0x20000994 <displays+20>)
    at ../../lib/protomatter/src/core.c:534
#1  0x10069238 in _PM_PWM_ISR () at ../../lib/protomatter/src/arch/rp2040.h:148
#2  <signal handler called>
#3  0x10068698 in _PM_init (core=core@entry=0x20000994 <displays+20>, 
    bitWidth=bitWidth@entry=64, bitDepth=bitDepth@entry=4 '\004', 
    rgbCount=<optimized out>, rgbCount@entry=1 '\001', 
    rgbList=rgbList@entry=0x20000a0c <displays+140> "\006\005\t\v\n\f", 
    addrCount=<optimized out>, 
    addrList=addrList@entry=0x20000a2a <displays+170> "\031\030\035\034", 
    clockPin=13 '\r', latchPin=latchPin@entry=1 '\001', 
    oePin=oePin@entry=0 '\000', doubleBuffer=doubleBuffer@entry=true, 
    tile=-1 '\377', timer=0x10003) at ../../lib/protomatter/src/core.c:119
#4  0x1005071a in common_hal_rgbmatrix_rgbmatrix_reconstruct (
    self=self@entry=0x20000980 <displays>, framebuffer=framebuffer@entry=0x0)
    at ../../shared-module/rgbmatrix/RGBMatrix.c:97
#5  0x1002fad6 in supervisor_display_move_memory ()
    at ../../supervisor/shared/display.c:144
#6  0x10039e2e in supervisor_move_memory ()
    at ../../supervisor/shared/memory.c:316
#7  0x1002621a in cleanup_after_vm (heap=0x200033b8 <allocations+8>)
    at ../../main.c:233
#8  run_repl () at ../../main.c:528
#9  main () at ../../main.c:593
```
This appears to be because an earlier `_PM_stop` or `_PM_pause` would not actually disable the `PWM_IRQ_WRAP`.