### PR TITLE
rp2040: circuitpython: Actually make dynamic PWM allocation work

### DIFF
--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -207,9 +207,9 @@ inline void _PM_timerStart(void *tptr, uint32_t period) {
   pwm_set_wrap(_PM_PWM_SLICE, period);
   pwm_set_enabled(_PM_PWM_SLICE, true);
 #else
-  irq_set_enabled(_PM_IRQ_HANDLER, true);                   // Enable alarm IRQ
-  _PM_timerSave = timer_hw->timerawl;                       // Time at start
-  timer_hw->alarm[_PM_ALARM_NUM] = _PM_timerSave + period;  // Time at end
+  irq_set_enabled(_PM_IRQ_HANDLER, true);                  // Enable alarm IRQ
+  _PM_timerSave = timer_hw->timerawl;                      // Time at start
+  timer_hw->alarm[_PM_ALARM_NUM] = _PM_timerSave + period; // Time at end
 #endif
 }
 


### PR DESCRIPTION
My initial testing was always done with PWM slice 0, so it didn't matter that _PM_pwm_slice was never set to a nonzero value.  Limor tested with the first pin as GPIO6, which led to use of slice 3 and after that everything got sad really quickly.

Since Arduino doesn't use _PM_pwm_slice now, this means that _PM_timerInit's implementation becomes unshared; because _PM_timerInit nees to refer to _PM_PWM_ISR or _PM_timerISR, those newly require forward (static) declarations.  That makes this change look bigger than it is. The only "real" change is intended to be something like
```c
 #ifdef CIRCUITPYTHON
 void _PM_timerInit(void *tptr) {
 #if _PM_CLOCK_PWM
+  _PM_pwm_slice = (int)tptr & 0xff;
```

With this iteration of the code, I successfully ran CircuitPython in these configurations:
 * my pinout, which uses PWM slice 0, on the pico fw, viewed on a real matrix
 * an alternate pinout which uses PWM slice 2 but is still visible (swaps R and B lines), on the pico fw, viewed on a real matrix
 * the feather pinout that limor used, tested on pico fw and feather fw, but not visible to me due to the pinout being different

... across resets, typing in the REPL, etc.