### PR TITLE
Add support for SAM E5x MCUs

### DIFF
--- a/src/arch/samd-common.h
+++ b/src/arch/samd-common.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if defined(__SAMD51__) || defined(SAMD51) || defined(_SAMD21_) ||             \
+#if defined(__SAMD51__) || defined(SAM_D5X_E5X) || defined(_SAMD21_) ||      \
     defined(SAMD21)
 
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
@@ -95,4 +95,4 @@ void _PM_IRQ_HANDLER(void) {
 
 #endif
 
-#endif // END SAMD51/SAMD21
+#endif // END SAMD5x/SAME5x/SAMD21

--- a/src/arch/samd-common.h
+++ b/src/arch/samd-common.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if defined(__SAMD51__) || defined(SAM_D5X_E5X) || defined(_SAMD21_) ||      \
+#if defined(__SAMD51__) || defined(SAM_D5X_E5X) || defined(_SAMD21_) ||        \
     defined(SAMD21)
 
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------

--- a/src/arch/samd51.h
+++ b/src/arch/samd51.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if defined(__SAMD51__) || defined(SAMD51) // Arduino, Circuitpy SAMD51 defs
+#if defined(__SAMD51__) || defined(SAM_D5X_E5X) // Arduino, Circuitpy SAMD5x / E5x defs
 
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 
@@ -212,4 +212,4 @@ uint32_t _PM_timerStop(void *tptr) {
 
 #define _PM_minMinPeriod 160
 
-#endif // END __SAMD51__ || SAMD51
+#endif // END __SAMD51__ || SAM_D5X_E5X

--- a/src/arch/samd51.h
+++ b/src/arch/samd51.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#if defined(__SAMD51__) || defined(SAM_D5X_E5X) // Arduino, Circuitpy SAMD5x / E5x defs
+#if defined(__SAMD51__) ||                                                     \
+    defined(SAM_D5X_E5X) // Arduino, Circuitpy SAMD5x / E5x defs
 
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 


### PR DESCRIPTION
.. such as in the Feather M4 CAN.

This is only compile-tested but the chips can be considered identical for these purposes. Will enable https://github.com/adafruit/circuitpython/pull/4591