### PR TITLE
RP2040 Arduino support

### DIFF
--- a/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
+++ b/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
@@ -70,6 +70,18 @@ supported boards.
   uint8_t clockPin   = 23; // A9
   uint8_t latchPin   = 6;
   uint8_t oePin      = 9;
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  // RP2040 support requires the Earle Philhower board support package;
+  // will not compile with the Arduino Mbed OS board package.
+  // The following pinout works with the Adafruit Feather RP2040 and
+  // original RGB Matrix FeatherWing (M0/M4/RP2040, not nRF version).
+  // Pin numbers here are GP## numbers, which may be different than
+  // the pins printed on some boards' top silkscreen.
+  uint8_t rgbPins[]  = {8, 7, 9, 11, 10, 12};
+  uint8_t addrPins[] = {25, 24, 29, 28};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 1;
+  uint8_t oePin      = 0;
 #endif
 
 /* ----------------------------------------------------------------------

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -75,6 +75,18 @@ supported boards. Notes have been moved to the bottom of the code.
   uint8_t clockPin   = 23; // A9
   uint8_t latchPin   = 6;
   uint8_t oePin      = 9;
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  // RP2040 support requires the Earle Philhower board support package;
+  // will not compile with the Arduino Mbed OS board package.
+  // The following pinout works with the Adafruit Feather RP2040 and
+  // original RGB Matrix FeatherWing (M0/M4/RP2040, not nRF version).
+  // Pin numbers here are GP## numbers, which may be different than
+  // the pins printed on some boards' top silkscreen.
+  uint8_t rgbPins[]  = {8, 7, 9, 11, 10, 12};
+  uint8_t addrPins[] = {25, 24, 29, 28};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 1;
+  uint8_t oePin      = 0;
 #endif
 
 /* ----------------------------------------------------------------------

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -72,6 +72,18 @@ supported boards.
   uint8_t clockPin   = 23; // A9
   uint8_t latchPin   = 6;
   uint8_t oePin      = 9;
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_RP2040)
+  // RP2040 support requires the Earle Philhower board support package;
+  // will not compile with the Arduino Mbed OS board package.
+  // The following pinout works with the Adafruit Feather RP2040 and
+  // original RGB Matrix FeatherWing (M0/M4/RP2040, not nRF version).
+  // Pin numbers here are GP## numbers, which may be different than
+  // the pins printed on some boards' top silkscreen.
+  uint8_t rgbPins[]  = {8, 7, 9, 11, 10, 12};
+  uint8_t addrPins[] = {25, 24, 29, 28};
+  uint8_t clockPin   = 13;
+  uint8_t latchPin   = 1;
+  uint8_t oePin      = 0;
 #endif
 
 /* ----------------------------------------------------------------------

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A library for Adafruit RGB LED matrices.
 paragraph=RGB LED matrix.
 category=Display
 url=https://github.com/adafruit/Adafruit_protomatter
-architectures=samd,nrf52,stm32,esp32
+architectures=samd,nrf52,stm32,esp32,rp2040
 depends=Adafruit GFX Library, Adafruit LIS3DH, Adafruit PixelDust, AnimatedGIF, Adafruit SPIFlash, Adafruit TinyUSB Library

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -186,7 +186,6 @@ static volatile uint32_t _PM_timerSave;
 // sets up this pointer when calling begin().
 void *_PM_protoPtr = NULL;
 
-
 #if _PM_CLOCK_PWM // Use PWM for timing
 static void _PM_PWM_ISR(void) {
   pwm_clear_irq(_PM_PWM_SLICE);  // Reset PWM wrap interrupt

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -104,7 +104,7 @@ void _PM_timerInit(void *tptr) {
 
 #elif defined(CIRCUITPY) // COMPILING FOR CIRCUITPYTHON --------------------
 
-#if !defined(F_CPU) // Not sure if CircuitPython build defines this
+#if !defined(F_CPU)     // Not sure if CircuitPython build defines this
 #define F_CPU 125000000 // Standard RP2040 clock speed
 #endif
 

--- a/src/arch/rp2040.h
+++ b/src/arch/rp2040.h
@@ -236,28 +236,18 @@ uint32_t _PM_timerStop(void *tptr) {
   return _PM_timerGetCount(tptr);
 }
 
-// TO DO: determine clock-holding NOPs needed for different CPU speeds.
-// Rates supported by Philhower core:
-// 50, 100, 125, 133, 150, 175, 200, 225, 250, 275, 300
-// These probably "bin" somewhat and don't need distinct defines for
-// every single one. At slowest speeds, can probably even leave undefined.
-// Original NOPs for 125 MHz were 2 for low and 1 for high.
-//#if (F_CPU >= something)
-//#define _PM_clockHoldLow asm("nop; nop;");
-//#define _PM_clockHoldHigh asm("nop;");
-//#elif (F_CPU >= something)
-//#define _PM_clockHoldLow asm("nop; nop;");
-//#define _PM_clockHoldHigh asm("nop;");
-//#elif (F_CPU >= something)
-//#define _PM_clockHoldLow asm("nop; nop;");
-//#define _PM_clockHoldHigh asm("nop;");
-//#else
-//#define _PM_clockHoldLow asm("nop; nop;");
-//#define _PM_clockHoldHigh asm("nop;");
-//#endif
-
+#if (F_CPU >= 250000000)
+#define _PM_clockHoldLow asm("nop; nop; nop;");
+#define _PM_clockHoldHigh asm("nop; nop; nop;");
+#elif (F_CPU >= 175000000)
 #define _PM_clockHoldLow asm("nop; nop;");
 #define _PM_clockHoldHigh asm("nop;");
+#elif (F_CPU >= 125000000)
+#define _PM_clockHoldLow asm("nop;");
+#define _PM_clockHoldHigh asm("nop;");
+#elif (F_CPU >= 100000000)
+#define _PM_clockHoldLow asm("nop;");
+#endif // No NOPs needed at lower speeds
 
 #define _PM_chunkSize 8
 #if _PM_CLOCK_PWM


### PR DESCRIPTION
Arduino RP2040 support enabled (via Philhower core) and 3 examples enabled (Feather-based ones that aren’t tied to board-specific features). Tested on a few matrix sizes & board F_CPU settings.

The NOP pulse timing for the default 125 MHz has changed slightly — from 2 NOPs low, 0 high, to 1 low, 1 high — else was seeing flicker. However, CircuitPython was apparently doing okay with the 2/0 setting. Since this code base is shared, it’s perhaps best to test the 1/1 timing there, and use this if it works in both places, otherwise move the _PM_clockHoldLow and _PM_clockHoldHigh macro definitions into the platform-specific sections of rp2040.h.

rp2040 added to architectures in library.properties, but version number is not bumped yet. Easily done via Github web UI if/when this is approved & merged.