### PR TITLE
Initial ESP32S3 Support

### DIFF
--- a/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
+++ b/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
@@ -45,6 +45,13 @@ supported boards.
   uint8_t clockPin   = 12;
   uint8_t latchPin   = PIN_SERIAL1_RX;
   uint8_t oePin      = PIN_SERIAL1_TX;
+#elif USB_VID == 0x239A && USB_PID == 0x8113 // Feather ESP32-S3 No PSRAM
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33
@@ -97,7 +104,7 @@ Adafruit_Protomatter matrix(
   1, rgbPins,  // # of matrix chains, array of 6 RGB pins for each
   4, addrPins, // # of address pins (height is inferred), array of pins
   clockPin, latchPin, oePin, // Other matrix control pins
-  true);       // HERE IS THE MAGIG FOR DOUBLE-BUFFERING!
+  true);       // HERE IS THE MAGIC FOR DOUBLE-BUFFERING!
 
 // Sundry globals used for animation ---------------------------------------
 

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -56,6 +56,13 @@ supported boards. Notes have been moved to the bottom of the code.
   uint8_t clockPin   = 12;
   uint8_t latchPin   = PIN_SERIAL1_RX;
   uint8_t oePin      = PIN_SERIAL1_TX;
+#elif USB_VID == 0x239A && USB_PID == 0x8113 // Feather ESP32-S3 No PSRAM
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -47,6 +47,13 @@ supported boards.
   uint8_t clockPin   = 12;
   uint8_t latchPin   = PIN_SERIAL1_RX;
   uint8_t oePin      = PIN_SERIAL1_TX;
+#elif USB_VID == 0x239A && USB_PID == 0x8113 // Feather ESP32-S3 No PSRAM
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Protomatter
-version=1.2.1
+version=1.2.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=A library for Adafruit RGB LED matrices.

--- a/src/arch/esp32.h
+++ b/src/arch/esp32.h
@@ -28,7 +28,7 @@
 #else
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
 #define _PM_STRICT_32BIT_IO ///< Change core.c behavior for long accesses only
-#endif // end ESP32S3
+#endif                      // end ESP32S3
 #define _PM_portOutRegister(pin)                                               \
   (volatile uint32_t *)((pin < 32) ? &GPIO.out : &GPIO.out1.val)
 #define _PM_portSetRegister(pin)                                               \


### PR DESCRIPTION
Tested, works on Feather ESP32-S3 no PSRAM. Slightly flickery with larger matrices at higher bit depths…I think this will just require some time with an oscilloscope and adjusting the least-bitplane time in the code on S3. Sufficient for some initial development though.