### PR TITLE
Add ESP32-S2 support (about the same as S3)

### DIFF
--- a/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
+++ b/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
@@ -52,6 +52,13 @@ supported boards.
   uint8_t clockPin   = 13; // Must be on same port as rgbPins
   uint8_t latchPin   = RX;
   uint8_t oePin      = TX;
+#elif USB_VID == 0x239A && USB_PID == 0x80EB // Feather ESP32-S2
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -63,6 +63,13 @@ supported boards. Notes have been moved to the bottom of the code.
   uint8_t clockPin   = 13; // Must be on same port as rgbPins
   uint8_t latchPin   = RX;
   uint8_t oePin      = TX;
+#elif USB_VID == 0x239A && USB_PID == 0x80EB // Feather ESP32-S2
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -54,6 +54,13 @@ supported boards.
   uint8_t clockPin   = 13; // Must be on same port as rgbPins
   uint8_t latchPin   = RX;
   uint8_t oePin      = TX;
+#elif USB_VID == 0x239A && USB_PID == 0x80EB // Feather ESP32-S2
+  // M0/M4/RP2040 Matrix FeatherWing compatible:
+  uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
+  uint8_t addrPins[] = {A5, A4, A3, A2};
+  uint8_t clockPin   = 13; // Must be on same port as rgbPins
+  uint8_t latchPin   = RX;
+  uint8_t oePin      = TX;
 #elif defined(ESP32)
   // 'Safe' pins, not overlapping any peripherals:
   // GPIO.out: 4, 12, 13, 14, 15, 21, 27, GPIO.out1: 32, 33

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Protomatter
-version=1.2.2
+version=1.2.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=A library for Adafruit RGB LED matrices.


### PR DESCRIPTION
Mostly just #ifdef changes to bring the recent S3 support to S2 as well. Examples updated for Feather ESP32-S2. Tweaked the least-bitplane minimum timer value to (maybe) help with flicker.