### PR TITLE
circuitpython / esp32-s3 fixes

### DIFF
--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -145,6 +145,15 @@ IRAM_ATTR uint32_t _PM_timerStop(Protomatter_core *core) {
   return _PM_timerGetCount(core);
 }
 
+// Return current count value (timer enabled or not).
+// Timer must be previously initialized.
+IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
+  timer_index_t *timer = (timer_index_t *)core->timer;
+  uint64_t value;
+  timer_ll_get_counter_value(timer->hw, timer->idx,&value);
+  return (uint32_t)value;
+}
+
 // Initialize, but do not start, timer. This function contains timer setup
 // that's common to all ESP32 variants; code in variant-specific files might
 // set up its own special peripherals, then call this.

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -150,7 +150,7 @@ IRAM_ATTR uint32_t _PM_timerStop(Protomatter_core *core) {
 IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
   timer_index_t *timer = (timer_index_t *)core->timer;
   uint64_t value;
-  timer_ll_get_counter_value(timer->hw, timer->idx,&value);
+  timer_ll_get_counter_value(timer->hw, timer->idx, &value);
   return (uint32_t)value;
 }
 

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -73,6 +73,9 @@ static uint32_t _PM_directBitMask(Protomatter_core *core, int pin) {
 
 // Thankfully, at present, any core code which calls _PM_portBitMask()
 // currently has a 'core' variable, so we can safely do this...
+// This replaces the version from esp32-common.h, and CircuitPython requires
+// the 'undef' be manually performed or an error is thrown at compile time.
+#undef _PM_portBitMask
 #define _PM_portBitMask(pin) _PM_directBitMask(core, pin)
 
 static dma_descriptor_t desc;
@@ -284,7 +287,7 @@ void _PM_timerInit(Protomatter_core *core) {
       .sibling_chan = NULL,
       .direction = GDMA_CHANNEL_DIRECTION_TX,
       .flags = {.reserve_sibling = 0}};
-  esp_err_t ret = gdma_new_channel(&dma_chan_config, &dma_chan);
+  (void)gdma_new_channel(&dma_chan_config, &dma_chan);
   gdma_connect(dma_chan, GDMA_MAKE_TRIGGER(GDMA_TRIG_PERIPH_LCD, 0));
   gdma_strategy_config_t strategy_config = {.owner_check = false,
                                             .auto_update_desc = false};


### PR DESCRIPTION
Eventually this will collect the changes to protomatter needed to bring circuitpython up to date and support esp32-s3. Right now it compiles but doesn't work (various problems not worth detailing).