### PR TITLE
    Add support for panels with FM6126A chipset. Copied from SmartMat…

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1340,7 +1340,7 @@ void resetFM6126A(Protomatter_core *core) {
     // set CLK/LAT to idle state
     _PM_pinLow(core->latch.pin);
     _PM_pinLow(core->clockPin);
-    delay(1);
+    _PM_delayMicroseconds(1);
 
     // Send Data to control register 11
     for (int i = 0; i < maxLeds; i++) {
@@ -1368,9 +1368,9 @@ void resetFM6126A(Protomatter_core *core) {
         }
 
         _PM_pinHigh(core->clockPin);
-        delay(1);
+        _PM_delayMicroseconds(1);
         _PM_pinLow(core->clockPin);
-        delay(1);
+        _PM_delayMicroseconds(1);
     }
 
     _PM_pinLow(core->latch.pin);
@@ -1401,9 +1401,9 @@ void resetFM6126A(Protomatter_core *core) {
         }
 
         _PM_pinHigh(core->clockPin);
-        delay(1);
+        _PM_delayMicroseconds(1);
         _PM_pinLow(core->clockPin);
-        delay(1);
+        _PM_delayMicroseconds(1);
     }
 
     _PM_pinLow(core->latch.pin);


### PR DESCRIPTION
Not sure if anyone needs it, but I have a bunch of these panels and now they work. Yay.
The fix adds one function - copied from SmartMatrix. Have not tested with 'normal' panels - I don't have any.
Might need to make this into an 'option'.

