### PR TITLE
Add MatrixPortal ESP32-S3 support in examples

### DIFF
--- a/examples/animated_gif/animated_gif.ino
+++ b/examples/animated_gif/animated_gif.ino
@@ -1,7 +1,7 @@
 // Play GIFs from CIRCUITPY drive (USB-accessible filesystem) to LED matrix.
-// ***DESIGNED FOR ADAFRUIT MATRIXPORTAL M4***, but may run on some other
-// M4 & M0 and nRF52 boards (relies on TinyUSB stack). As written, runs on
-// 64x32 pixel matrix, this can be changed by editing the WIDTH and HEIGHT
+// ***DESIGNED FOR ADAFRUIT MATRIXPORTAL***, but may run on some other M4,
+// M0, ESP32S3 and nRF52 boards (relies on TinyUSB stack). As written, runs
+// on 64x32 pixel matrix, this can be changed by editing the WIDTH and HEIGHT
 // definitions. See the "simple" example for a run-down on matrix config.
 // Adapted from examples from Larry Bank's AnimatedGIF library and
 // msc_external_flash example in Adafruit_TinyUSB_Arduino.
@@ -33,7 +33,9 @@ uint16_t GIFminimumTime = 10; // Min. repeat time (seconds) until next GIF
 // FLASH FILESYSTEM STUFF --------------------------------------------------
 
 // External flash macros for QSPI or SPI are defined in board variant file.
-#if defined(EXTERNAL_FLASH_USE_QSPI)
+#if defined(ARDUINO_ARCH_ESP32)
+static Adafruit_FlashTransport_ESP32 flashTransport;
+#elif defined(EXTERNAL_FLASH_USE_QSPI)
 Adafruit_FlashTransport_QSPI flashTransport;
 #elif defined(EXTERNAL_FLASH_USE_SPI)
 Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
@@ -56,6 +58,14 @@ uint8_t latchPin = 15;
 uint8_t oePin = 16;
 #define BACK_BUTTON 2
 #define NEXT_BUTTON 3
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3)
+uint8_t rgbPins[] = {42, 41, 40, 38, 39, 37};
+uint8_t addrPins[] = {35, 36, 48, 45, 21}; // 16/32/64 pixels tall
+uint8_t clockPin = 2;
+uint8_t latchPin = 47;
+uint8_t oePin = 14;
+#define BACK_BUTTON 6
+#define NEXT_BUTTON 7
 #elif defined(_VARIANT_METRO_M4_)
 uint8_t rgbPins[] = {2, 3, 4, 5, 6, 7};
 uint8_t addrPins[] = {A0, A1, A2, A3}; // 16 or 32 pixels tall
@@ -89,7 +99,7 @@ int16_t xPos = 0, yPos = 0; // Top-left pixel coord of GIF in matrix space
 // FILE ACCESS FUNCTIONS REQUIRED BY ANIMATED GIF LIB ----------------------
 
 // Pass in ABSOLUTE PATH of GIF file to open
-void *GIFOpenFile(char *filename, int32_t *pSize) {
+void *GIFOpenFile(const char *filename, int32_t *pSize) {
   GIFfile = filesys.open(filename);
   if (GIFfile) {
     *pSize = GIFfile.size();

--- a/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
+++ b/examples/doublebuffer_scrolltext/doublebuffer_scrolltext.ino
@@ -21,6 +21,12 @@ supported boards.
   uint8_t clockPin   = 14;
   uint8_t latchPin   = 15;
   uint8_t oePin      = 16;
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
+  uint8_t rgbPins[]  = {42, 41, 40, 38, 39, 37};
+  uint8_t addrPins[] = {35, 36, 48, 45, 21};
+  uint8_t clockPin   = 2;
+  uint8_t latchPin   = 47;
+  uint8_t oePin      = 14;
 #elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
   uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
   uint8_t addrPins[] = {A5, A4, A3, A2};

--- a/examples/pixeldust/pixeldust.ino
+++ b/examples/pixeldust/pixeldust.ino
@@ -23,7 +23,7 @@ uint8_t addrPins[] = {17, 18, 19, 20, 21};
 uint8_t clockPin   = 14;
 uint8_t latchPin   = 15;
 uint8_t oePin      = 16;
-#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
+#else // MatrixPortal ESP32-S3
 uint8_t rgbPins[]  = {42, 41, 40, 38, 39, 37};
 uint8_t addrPins[] = {35, 36, 48, 45, 21};
 uint8_t clockPin   = 2;

--- a/examples/pixeldust/pixeldust.ino
+++ b/examples/pixeldust/pixeldust.ino
@@ -1,6 +1,6 @@
 /* ----------------------------------------------------------------------
 "Pixel dust" Protomatter library example. As written, this is
-SPECIFICALLY FOR THE ADAFRUIT MATRIXPORTAL M4 with 64x32 pixel matrix.
+SPECIFICALLY FOR THE ADAFRUIT MATRIXPORTAL with 64x32 pixel matrix.
 Change "HEIGHT" below for 64x64 matrix. Could also be adapted to other
 Protomatter-capable boards with an attached LIS3DH accelerometer.
 
@@ -17,21 +17,30 @@ or "doublebuffer" for animation basics.
 #define WIDTH   64 // Matrix width (pixels)
 #define MAX_FPS 45 // Maximum redraw rate, frames/second
 
-#if HEIGHT == 64 // 64-pixel tall matrices have 5 address lines:
-uint8_t addrPins[] = {17, 18, 19, 20, 21};
-#else            // 32-pixel tall matrices have 4 address lines:
-uint8_t addrPins[] = {17, 18, 19, 20};
-#endif
-
-// Remaining pins are the same for all matrix sizes. These values
-// are for MatrixPortal M4. See "simple" example for other boards.
+#if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
 uint8_t rgbPins[]  = {7, 8, 9, 10, 11, 12};
+uint8_t addrPins[] = {17, 18, 19, 20, 21};
 uint8_t clockPin   = 14;
 uint8_t latchPin   = 15;
 uint8_t oePin      = 16;
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
+uint8_t rgbPins[]  = {42, 41, 40, 38, 39, 37};
+uint8_t addrPins[] = {35, 36, 48, 45, 21};
+uint8_t clockPin   = 2;
+uint8_t latchPin   = 47;
+uint8_t oePin      = 14;
+#endif
+
+#if HEIGHT == 16
+#define NUM_ADDR_PINS 3
+#elif HEIGHT == 32
+#define NUM_ADDR_PINS 4
+#elif HEIGHT == 64
+#define NUM_ADDR_PINS 5
+#endif
 
 Adafruit_Protomatter matrix(
-  WIDTH, 4, 1, rgbPins, sizeof(addrPins), addrPins,
+  WIDTH, 4, 1, rgbPins, NUM_ADDR_PINS, addrPins,
   clockPin, latchPin, oePin, true);
 
 Adafruit_LIS3DH accel = Adafruit_LIS3DH();

--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -26,6 +26,12 @@ supported boards. Notes have been moved to the bottom of the code.
   uint8_t clockPin   = 14;
   uint8_t latchPin   = 15;
   uint8_t oePin      = 16;
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
+  uint8_t rgbPins[]  = {42, 41, 40, 38, 39, 37};
+  uint8_t addrPins[] = {35, 36, 48, 45, 21};
+  uint8_t clockPin   = 2;
+  uint8_t latchPin   = 47;
+  uint8_t oePin      = 14;
 #elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
   uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
   uint8_t addrPins[] = {A5, A4, A3, A2};

--- a/examples/tiled/tiled.ino
+++ b/examples/tiled/tiled.ino
@@ -23,6 +23,12 @@ supported boards.
   uint8_t clockPin   = 14;
   uint8_t latchPin   = 15;
   uint8_t oePin      = 16;
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
+  uint8_t rgbPins[]  = {42, 41, 40, 38, 39, 37};
+  uint8_t addrPins[] = {35, 36, 48, 45, 21};
+  uint8_t clockPin   = 2;
+  uint8_t latchPin   = 47;
+  uint8_t oePin      = 14;
 #elif defined(_VARIANT_FEATHER_M4_) // Feather M4 + RGB Matrix FeatherWing
   uint8_t rgbPins[]  = {6, 5, 9, 11, 10, 12};
   uint8_t addrPins[] = {A5, A4, A3, A2};

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Protomatter
-version=1.5.4
+version=1.5.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=A library for Adafruit RGB LED matrices.


### PR DESCRIPTION
The animated_gif example currently does NOT compile for ESP32-S3 (works on M4). Issue may be in Adafruit_TinyUSB, as other examples from that library _also_ don’t currently compile for S3. Once that’s sorted out, I expect this will work. Other examples are tested and work on both M4 and ESP32-S3.