### PR TITLE
Updates for CircuitPython compatibility

### DIFF
--- a/src/arch/esp32-c3.h
+++ b/src/arch/esp32-c3.h
@@ -42,14 +42,13 @@
 // No special peripheral setup on ESP32C3, just use common timer init...
 #define _PM_timerInit(core) _PM_esp32commonTimerInit(core);
 
+#if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 // Return current count value (timer enabled or not).
 // Timer must be previously initialized.
 // This function is the same on all ESP32 parts EXCEPT S3.
 IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
   return (uint32_t)timerRead((hw_timer_t *)core->timer);
 }
-
-#if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 
 #elif defined(CIRCUITPY) // COMPILING FOR CIRCUITPYTHON --------------------
 

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#if defined(ESP32) || defined(ESP_PLATFORM) // *All* ESP32 variants (OG, S2, S3, etc.)
+#if defined(ESP32) ||                                                          \
+    defined(ESP_PLATFORM) // *All* ESP32 variants (OG, S2, S3, etc.)
 
 #include "esp_idf_version.h"
 

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -117,7 +117,7 @@ void _PM_esp32commonTimerInit(Protomatter_core *core) {
 // (RAM-resident functions). This isn't really the ISR itself, but a
 // callback invoked by the real ISR (in arduino-esp32's esp32-hal-timer.c)
 // which takes care of interrupt status bits & such.
-IRAM_ATTR bool _PM_esp32timerCallback(void *unused) {
+static IRAM_ATTR bool _PM_esp32timerCallback(void *unused) {
   if (_PM_protoPtr) {
     _PM_row_handler(_PM_protoPtr); // In core.c
   }
@@ -126,7 +126,7 @@ IRAM_ATTR bool _PM_esp32timerCallback(void *unused) {
 
 // Set timer period, initialize count value to zero, enable timer.
 #if (ESP_IDF_VERSION_MAJOR == 5)
-IRAM_ATTR void _PM_timerStart(Protomatter_core *core, uint32_t period) {
+static IRAM_ATTR void _PM_timerStart(Protomatter_core *core, uint32_t period) {
   timer_index_t *timer = (timer_index_t *)core->timer;
   timer_ll_enable_counter(timer->hw, timer->idx, false);
   timer_ll_set_reload_value(timer->hw, timer->idx, 0);
@@ -171,7 +171,7 @@ IRAM_ATTR uint32_t _PM_timerGetCount(Protomatter_core *core) {
 // Initialize, but do not start, timer. This function contains timer setup
 // that's common to all ESP32 variants; code in variant-specific files might
 // set up its own special peripherals, then call this.
-void _PM_esp32commonTimerInit(Protomatter_core *core) {
+static void _PM_esp32commonTimerInit(Protomatter_core *core) {
   timer_index_t *timer = (timer_index_t *)core->timer;
   const timer_config_t config = {
       .alarm_en = false,

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if defined(ESP32) // *All* ESP32 variants (OG, S2, S3, etc.)
+#if defined(ESP32) || defined(ESP_PLATFORM) // *All* ESP32 variants (OG, S2, S3, etc.)
 
 #include "esp_idf_version.h"
 

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -158,13 +158,12 @@ IRAM_ATTR uint32_t _PM_timerStop(Protomatter_core *core) {
   return _PM_timerGetCount(core);
 }
 
-#if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
+#if !defined(CONFIG_IDF_TARGET_ESP32S3)
 IRAM_ATTR uint32_t _PM_timerGetCount(Protomatter_core *core) {
   timer_index_t *timer = (timer_index_t *)core->timer;
-  timer->hw->hw_timer[timer->idx].update.tn_update = 1;
-  return timer->hw->hw_timer[timer->idx].lo.tn_lo;
-  timer->hw->hw_timer[timer->idx].update.tx_update = 1;
-  return timer->hw->hw_timer[timer->idx].lo.tx_lo;
+  uint64_t result;
+  timer_ll_get_counter_value(timer->hw, timer->idx, &result);
+  return (uint32_t)result;
 }
 #endif
 

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -19,6 +19,8 @@
 
 #if defined(ESP32) // *All* ESP32 variants (OG, S2, S3, etc.)
 
+#include "esp_idf_version.h"
+
 // NOTE: there is some intentional repetition in the macros and functions
 // for some ESP32 variants. Previously they were all one file, but complex
 // preprocessor directives were turning into spaghetti. THEREFORE, if making

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -158,16 +158,15 @@ IRAM_ATTR uint32_t _PM_timerStop(Protomatter_core *core) {
   return _PM_timerGetCount(core);
 }
 
+#if !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
 IRAM_ATTR uint32_t _PM_timerGetCount(Protomatter_core *core) {
   timer_index_t *timer = (timer_index_t *)core->timer;
-#ifdef CONFIG_IDF_TARGET_ESP32S3
   timer->hw->hw_timer[timer->idx].update.tn_update = 1;
   return timer->hw->hw_timer[timer->idx].lo.tn_lo;
-#else
   timer->hw->hw_timer[timer->idx].update.tx_update = 1;
   return timer->hw->hw_timer[timer->idx].lo.tx_lo;
-#endif
 }
+#endif
 
 // Initialize, but do not start, timer. This function contains timer setup
 // that's common to all ESP32 variants; code in variant-specific files might

--- a/src/arch/esp32-common.h
+++ b/src/arch/esp32-common.h
@@ -32,7 +32,7 @@
 
 // As currently written, only one instance of the Protomatter_core struct
 // is allowed, set up when calling begin()...so it's just a global here:
-void *_PM_protoPtr = NULL;
+Protomatter_core *_PM_protoPtr;
 
 #define _PM_timerFreq 40000000 // 40 MHz (1:2 prescale)
 

--- a/src/arch/esp32-s2.h
+++ b/src/arch/esp32-s2.h
@@ -139,13 +139,6 @@ IRAM_ATTR static void blast_byte(Protomatter_core *core, uint8_t *data) {
 IRAM_ATTR static void blast_word(Protomatter_core *core, uint16_t *data) {}
 IRAM_ATTR static void blast_long(Protomatter_core *core, uint32_t *data) {}
 
-// Return current count value (timer enabled or not).
-// Timer must be previously initialized.
-// This function is the same on all ESP32 parts EXCEPT S3.
-IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
-  return (uint32_t)timerRead((hw_timer_t *)core->timer);
-}
-
 #if defined(ARDUINO) // COMPILING FOR ARDUINO ------------------------------
 
 void _PM_timerInit(Protomatter_core *core) {
@@ -172,6 +165,13 @@ void _PM_timerInit(Protomatter_core *core) {
   DEDIC_GPIO.gpio_out_cpu.val = 0; // Use GPIO registers, not CPU instructions
 
   _PM_esp32commonTimerInit(core); // In esp32-common.h
+}
+
+// Return current count value (timer enabled or not).
+// Timer must be previously initialized.
+// This function is the same on all ESP32 parts EXCEPT S3.
+IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
+  return (uint32_t)timerRead((hw_timer_t *)core->timer);
 }
 
 #elif defined(CIRCUITPY) // COMPILING FOR CIRCUITPYTHON --------------------
@@ -206,6 +206,16 @@ void _PM_timerInit(Protomatter_core *core) {
   DEDIC_GPIO.gpio_out_cpu.val = 0; // Use GPIO registers, not CPU instructions
 
   _PM_esp32commonTimerInit(core); // In esp32-common.h
+}
+
+// Return current count value (timer enabled or not).
+// Timer must be previously initialized.
+// This function is the same on all ESP32 parts EXCEPT S3.
+IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
+  uint64_t value;
+  timer_index_t *timer = (timer_index_t*)core->timer;
+  timer_get_counter_value(timer->group, timer->idx,&value);
+  retur (uint32_t)value;
 }
 
 #endif // END CIRCUITPYTHON ------------------------------------------------

--- a/src/arch/esp32-s2.h
+++ b/src/arch/esp32-s2.h
@@ -215,7 +215,7 @@ IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
   uint64_t value;
   timer_index_t *timer = (timer_index_t*)core->timer;
   timer_get_counter_value(timer->group, timer->idx,&value);
-  retur (uint32_t)value;
+  return (uint32_t)value;
 }
 
 #endif // END CIRCUITPYTHON ------------------------------------------------

--- a/src/arch/esp32-s2.h
+++ b/src/arch/esp32-s2.h
@@ -208,16 +208,6 @@ void _PM_timerInit(Protomatter_core *core) {
   _PM_esp32commonTimerInit(core); // In esp32-common.h
 }
 
-// Return current count value (timer enabled or not).
-// Timer must be previously initialized.
-// This function is the same on all ESP32 parts EXCEPT S3.
-IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
-  uint64_t value;
-  timer_index_t *timer = (timer_index_t*)core->timer;
-  timer_get_counter_value(timer->group, timer->idx,&value);
-  return (uint32_t)value;
-}
-
 #endif // END CIRCUITPYTHON ------------------------------------------------
 
 #endif // END ESP32S2

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -143,8 +143,8 @@ IRAM_ATTR static void blast_byte(Protomatter_core *core, uint8_t *data) {
   // Timer was cleared to 0 before calling blast_byte(), so this
   // is the state of the timer immediately after DMA started:
   uint64_t value;
-  timer_index_t *timer = (timer_index_t*)core->timer;
-  timer_get_counter_value(timer->group, timer->idx,&value);
+  timer_index_t *timer = (timer_index_t *)core->timer;
+  timer_get_counter_value(timer->group, timer->idx, &value);
   dmaSetupTime = (uint32_t)value;
   // See notes near top of this file for what's done with this info.
 }

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -25,6 +25,9 @@
 
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
 
+#include "components/esp_rom/include/esp_rom_sys.h"
+#include "components/heap/include/esp_heap_caps.h"
+
 // Use DMA-capable RAM (not PSRAM) for framebuffer:
 #define _PM_allocate(x) heap_caps_malloc(x, MALLOC_CAP_DMA | MALLOC_CAP_8BIT)
 #define _PM_free(x) heap_caps_free(x)

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -255,7 +255,7 @@ void _PM_timerInit(Protomatter_core *core) {
 
 #elif defined(CIRCUITPY) // COMPILING FOR CIRCUITPYTHON --------------------
 
-void _PM_timerInit(Protomatter_core *core) {
+static void _PM_timerInit(Protomatter_core *core) {
 
   // TO DO: adapt this function for any CircuitPython-specific changes.
   // If none are required, this function can be deleted and the version

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -74,7 +74,7 @@ IRAM_ATTR inline uint32_t _PM_timerGetCount(Protomatter_core *core) {
 // slightly different length of time, but duty cycle scales with this so it's
 // perceptually consistent; don't see bright or dark rows.
 
-#define _PM_minMinPeriod (200 + core->chainBits * 2)
+#define _PM_minMinPeriod (200 + (uint32_t)core->chainBits * 2)
 
 #if (ESP_IDF_VERSION_MAJOR == 5)
 #include <esp_private/periph_ctrl.h>

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -335,20 +335,22 @@ static void _PM_timerInit(Protomatter_core *core) {
   desc.next = NULL;
 
   // Alloc DMA channel & connect it to LCD periph
-  gdma_channel_alloc_config_t dma_chan_config = {
-      .sibling_chan = NULL,
-      .direction = GDMA_CHANNEL_DIRECTION_TX,
-      .flags = {.reserve_sibling = 0}};
-  gdma_new_channel(&dma_chan_config, &dma_chan);
-  gdma_connect(dma_chan, GDMA_MAKE_TRIGGER(GDMA_TRIG_PERIPH_LCD, 0));
-  gdma_strategy_config_t strategy_config = {.owner_check = false,
-                                            .auto_update_desc = false};
-  gdma_apply_strategy(dma_chan, &strategy_config);
-  gdma_transfer_ability_t ability = {
-      .sram_trans_align = 0,
-      .psram_trans_align = 0,
-  };
-  gdma_set_transfer_ability(dma_chan, &ability);
+  if (dma_chan == NULL) {
+    gdma_channel_alloc_config_t dma_chan_config = {
+        .sibling_chan = NULL,
+        .direction = GDMA_CHANNEL_DIRECTION_TX,
+        .flags = {.reserve_sibling = 0}};
+    gdma_new_channel(&dma_chan_config, &dma_chan);
+    gdma_connect(dma_chan, GDMA_MAKE_TRIGGER(GDMA_TRIG_PERIPH_LCD, 0));
+    gdma_strategy_config_t strategy_config = {.owner_check = false,
+                                              .auto_update_desc = false};
+    gdma_apply_strategy(dma_chan, &strategy_config);
+    gdma_transfer_ability_t ability = {
+        .sram_trans_align = 0,
+        .psram_trans_align = 0,
+    };
+    gdma_set_transfer_ability(dma_chan, &ability);
+  }
   gdma_start(dma_chan, (intptr_t)&desc);
 
   // Enable TRANS_DONE interrupt. Note that we do NOT require nor install

--- a/src/arch/esp32-s3.h
+++ b/src/arch/esp32-s3.h
@@ -139,7 +139,10 @@ IRAM_ATTR static void blast_byte(Protomatter_core *core, uint8_t *data) {
 
   // Timer was cleared to 0 before calling blast_byte(), so this
   // is the state of the timer immediately after DMA started:
-  dmaSetupTime = (uint32_t)timerRead((hw_timer_t *)core->timer);
+  uint64_t value;
+  timer_index_t *timer = (timer_index_t*)core->timer;
+  timer_get_counter_value(timer->group, timer->idx,&value);
+  dmaSetupTime = (uint32_t)value;
   // See notes near top of this file for what's done with this info.
 }
 


### PR DESCRIPTION
I found that changes were needed to make current protomatter work with circuitpython, particularly on the esp32-s3.

This has now been tested by @makermelissa on a range of circuitpython boards, and passes CI.