### PR TITLE
ESP32-S3: fix GPIO strength, dial down bit clock to ~17.8 MHz

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Protomatter
-version=1.6.0
+version=1.6.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=A library for Adafruit RGB LED matrices.


### PR DESCRIPTION
This PR addresses two issues specific to ESP32-S3. Other devices should be unaffected:

- GPIO drive strength was previously set incorrectly (it was assumed GPIO_DRIVE_CAP_MAX was the maximum value; it’s actually the _number_ of values, and max index is this minus one). Now a #define at the top of the file (used both for Arduino and CircuitPython). Currently set at GPIO_DRIVE_CAP_3, seems to work, but note that on M4 there was an issue due to the Matrix Portal level shifter that required using min strength…so if Problems™ are encountered in the future, might need to change this for S3. At least it’s in one simple place now.
- Pixel clock has been dialed down from 20 MHz to ~17.8 MHz, which reduces visual glitches, especially on long chains. This may mean lower refresh rates with some setups, one can compensate with a lower bit depth. Can be dialed down further if needed. A #define near the top of the code currently allows 20/17.8/16 MHz selections.