### PR TITLE
Added function to convert 24bit color to 565 color

### DIFF
--- a/src/Adafruit_Protomatter.cpp
+++ b/src/Adafruit_Protomatter.cpp
@@ -139,3 +139,18 @@ uint16_t Adafruit_Protomatter::colorHSV(uint16_t hue, uint8_t sat,
          ((((((g * s1) >> 8) + s2) * v1) & 0xFC00) >> 5) |
          (((((b * s1) >> 8) + s2) * v1) >> 11);
 }
+
+
+// 16-bit RGB565 output for GFX lib rather than 24-bit.
+// accepts a 24 bit color value packed into an int.
+// bits 23-16 = red, bits 15-8 = green, bits 7-0 = blue
+// returns RGB color in 565 format
+uint16_t Adafruit_Protomatter::color24bit(int c) {
+  uint8_t r = (c >> 16) & 0xFF;
+  uint8_t g = (c >> 8) & 0xFF;
+  uint8_t b = c & 0xFF;
+  return color565(r,g,b);
+}
+
+
+

--- a/src/Adafruit_Protomatter.h
+++ b/src/Adafruit_Protomatter.h
@@ -128,6 +128,21 @@ public:
   }
 
   /*!
+    @brief  Converts 24-bit color (parameter passed as int) used in
+            a lot of existing graphics code, down to the "565" color format
+            used by Adafruit_GFX. Might get further quantized by matrix if
+            using less than 6-bit depth.
+    @param  24 bit RGB value packed into an int
+            top 8 bits  Red 
+            middle 8 bits Green 
+            bottom 8 bits Blue
+    @return Packed 16-bit (uint16_t) color value suitable for GFX drawing
+            functions.
+  */
+  uint16_t color24bit(int color);
+ 
+
+  /*!
     @brief   Convert hue, saturation and value into a packed 16-bit RGB color
              that can be passed to GFX drawing functions.
     @param   hue  An unsigned 16-bit value, 0 to 65535, representing one full


### PR DESCRIPTION

## Describe the scope of your change
- Added the function `uint16_t color24bit(int)` which takes a 24 bit RGB color and uses `uint16_t color565(uint8_t, uint8_t, uint8_t)` to generate the 565 color format to return.

## Describe any known limitations with your change
- There are no imitations to this change. It is non-breaking and not necessary to use.

## Please run any tests or examples that can exercise your modified code
- I have been using a forked version of [MatrixFireFast](https://github.com/biomurph/MatrixFireFast) to drive a 160x32 led panel. My working code is [MatrixFireFast_FK-8F1](https://github.com/biomurph/MatrixFireFast/tree/master/MatrixFireFast_FK-8F1)
